### PR TITLE
Add thread delay to all jmeter scripts

### DIFF
--- a/distribution/scripts/jmeter/authenticate/Authenticate_Super_Tenant_User.jmx
+++ b/distribution/scripts/jmeter/authenticate/Authenticate_Super_Tenant_User.jmx
@@ -64,6 +64,12 @@
             <stringProp name="Argument.value">${__P(time,10)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -188,6 +194,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_AuthCode_Redirect_WithConsent.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_AuthCode_Redirect_WithConsent.jmx
@@ -88,6 +88,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -485,6 +491,11 @@ ${password}</stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_Client_Credentials_Grant.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_Client_Credentials_Grant.jmx
@@ -74,6 +74,12 @@
             <stringProp name="Argument.value">${__P(apps,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -186,6 +192,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_Implicit_Redirect_WithConsent.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_Implicit_Redirect_WithConsent.jmx
@@ -94,6 +94,12 @@
             <stringProp name="Argument.value">${__P(apps,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -404,6 +410,11 @@ ${password}</stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_Password_Grant.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_Password_Grant.jmx
@@ -89,6 +89,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -228,6 +234,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_Password_Grant_Refresh_Token.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_Password_Grant_Refresh_Token.jmx
@@ -84,6 +84,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -304,6 +310,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_Password_Grant_Token_Introspection.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_Password_Grant_Token_Introspection.jmx
@@ -84,6 +84,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -292,6 +298,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oauth/OAuth_Password_Grant_Token_Revocation.jmx
+++ b/distribution/scripts/jmeter/oauth/OAuth_Password_Grant_Token_Revocation.jmx
@@ -84,6 +84,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -304,6 +310,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/distribution/scripts/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -88,6 +88,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -495,6 +501,11 @@ ${password}</stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oidc/OIDC_AuthCode_Request_Path_Authenticator_WithConsent.jmx
+++ b/distribution/scripts/jmeter/oidc/OIDC_AuthCode_Request_Path_Authenticator_WithConsent.jmx
@@ -88,6 +88,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -395,6 +401,11 @@ log.info(&quot;=================================&quot;);
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oidc/OIDC_Implicit_Redirect_WithConsent.jmx
+++ b/distribution/scripts/jmeter/oidc/OIDC_Implicit_Redirect_WithConsent.jmx
@@ -89,6 +89,12 @@
             <stringProp name="Argument.value">${__P(rampUpPeriod,10)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -417,6 +423,11 @@ ${password}</stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/oidc/OIDC_Password_Grant.jmx
+++ b/distribution/scripts/jmeter/oidc/OIDC_Password_Grant.jmx
@@ -89,6 +89,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -245,6 +251,11 @@ if (y == 0) {
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
+++ b/distribution/scripts/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
@@ -89,6 +89,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -306,6 +312,11 @@ ${password}
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/saml/SAML2_SSO_Request_Path_Authentication.jmx
+++ b/distribution/scripts/jmeter/saml/SAML2_SSO_Request_Path_Authentication.jmx
@@ -89,6 +89,12 @@
             <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -252,6 +258,11 @@ vars.put(&quot;sectoken&quot;, new String(encodeCredentials));
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
+        <hashTree/>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>

--- a/distribution/scripts/jmeter/scim2/SCIM2_Add_User.jmx
+++ b/distribution/scripts/jmeter/scim2/SCIM2_Add_User.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+<jmeterTestPlan version="1.2" properties="4.0" jmeter="4.0 r1823414">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="SCIM2 Add User - TestPlan" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -62,6 +62,12 @@
           <elementProp name="rampUpPeriod" elementType="Argument">
             <stringProp name="Argument.name">rampUpPeriod</stringProp>
             <stringProp name="Argument.value">${__P(rampUpPeriod,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -171,41 +177,10 @@
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
-        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
-          <boolProp name="ResultCollector.error_logging">false</boolProp>
-          <objProp>
-            <name>saveConfig</name>
-            <value class="SampleSaveConfiguration">
-              <time>true</time>
-              <latency>true</latency>
-              <timestamp>true</timestamp>
-              <success>true</success>
-              <label>true</label>
-              <code>true</code>
-              <message>true</message>
-              <threadName>true</threadName>
-              <dataType>true</dataType>
-              <encoding>false</encoding>
-              <assertions>true</assertions>
-              <subresults>true</subresults>
-              <responseData>false</responseData>
-              <samplerData>false</samplerData>
-              <xml>false</xml>
-              <fieldNames>true</fieldNames>
-              <responseHeaders>false</responseHeaders>
-              <requestHeaders>false</requestHeaders>
-              <responseDataOnError>false</responseDataOnError>
-              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
-              <assertionsResultsToSave>0</assertionsResultsToSave>
-              <bytes>true</bytes>
-              <sentBytes>true</sentBytes>
-              <threadCounts>true</threadCounts>
-              <idleTime>true</idleTime>
-              <connectTime>true</connectTime>
-            </value>
-          </objProp>
-          <stringProp name="filename"></stringProp>
-        </ResultCollector>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
         <hashTree/>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">

--- a/distribution/scripts/jmeter/scim2/SCIM2_Get_User_By_ID.jmx
+++ b/distribution/scripts/jmeter/scim2/SCIM2_Get_User_By_ID.jmx
@@ -76,6 +76,12 @@
             <stringProp name="Argument.metadata">=</stringProp>
             <stringProp name="Argument.desc">If just file is provided, will be saved in JMeter bin folder</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -156,41 +162,10 @@
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
-        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
-          <boolProp name="ResultCollector.error_logging">false</boolProp>
-          <objProp>
-            <name>saveConfig</name>
-            <value class="SampleSaveConfiguration">
-              <time>true</time>
-              <latency>true</latency>
-              <timestamp>true</timestamp>
-              <success>true</success>
-              <label>true</label>
-              <code>true</code>
-              <message>true</message>
-              <threadName>true</threadName>
-              <dataType>true</dataType>
-              <encoding>false</encoding>
-              <assertions>true</assertions>
-              <subresults>true</subresults>
-              <responseData>false</responseData>
-              <samplerData>false</samplerData>
-              <xml>false</xml>
-              <fieldNames>true</fieldNames>
-              <responseHeaders>false</responseHeaders>
-              <requestHeaders>false</requestHeaders>
-              <responseDataOnError>false</responseDataOnError>
-              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
-              <assertionsResultsToSave>0</assertionsResultsToSave>
-              <bytes>true</bytes>
-              <sentBytes>true</sentBytes>
-              <threadCounts>true</threadCounts>
-              <idleTime>true</idleTime>
-              <connectTime>true</connectTime>
-            </value>
-          </objProp>
-          <stringProp name="filename"></stringProp>
-        </ResultCollector>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
         <hashTree/>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>

--- a/distribution/scripts/jmeter/scim2/SCIM2_Get_User_By_Username.jmx
+++ b/distribution/scripts/jmeter/scim2/SCIM2_Get_User_By_Username.jmx
@@ -69,6 +69,12 @@
             <stringProp name="Argument.value">${__P(userCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -154,44 +160,13 @@
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
-        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
-          <boolProp name="ResultCollector.error_logging">false</boolProp>
-          <objProp>
-            <name>saveConfig</name>
-            <value class="SampleSaveConfiguration">
-              <time>true</time>
-              <latency>true</latency>
-              <timestamp>true</timestamp>
-              <success>true</success>
-              <label>true</label>
-              <code>true</code>
-              <message>true</message>
-              <threadName>true</threadName>
-              <dataType>true</dataType>
-              <encoding>false</encoding>
-              <assertions>true</assertions>
-              <subresults>true</subresults>
-              <responseData>false</responseData>
-              <samplerData>false</samplerData>
-              <xml>false</xml>
-              <fieldNames>true</fieldNames>
-              <responseHeaders>false</responseHeaders>
-              <requestHeaders>false</requestHeaders>
-              <responseDataOnError>false</responseDataOnError>
-              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
-              <assertionsResultsToSave>0</assertionsResultsToSave>
-              <bytes>true</bytes>
-              <sentBytes>true</sentBytes>
-              <threadCounts>true</threadCounts>
-              <idleTime>true</idleTime>
-              <connectTime>true</connectTime>
-            </value>
-          </objProp>
-          <stringProp name="filename"></stringProp>
-        </ResultCollector>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
         <hashTree/>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>

--- a/distribution/scripts/jmeter/scim2/SCIM2_Update_User_By_ID.jmx
+++ b/distribution/scripts/jmeter/scim2/SCIM2_Update_User_By_ID.jmx
@@ -81,6 +81,12 @@
             <stringProp name="Argument.value">${__P(userCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="threadDelay" elementType="Argument">
+            <stringProp name="Argument.name">threadDelay</stringProp>
+            <stringProp name="Argument.value">${__P(threadDelay,0)}</stringProp>
+            <stringProp name="Argument.desc">milliseconds</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -196,41 +202,10 @@
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
-        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
-          <boolProp name="ResultCollector.error_logging">false</boolProp>
-          <objProp>
-            <name>saveConfig</name>
-            <value class="SampleSaveConfiguration">
-              <time>true</time>
-              <latency>true</latency>
-              <timestamp>true</timestamp>
-              <success>true</success>
-              <label>true</label>
-              <code>true</code>
-              <message>true</message>
-              <threadName>true</threadName>
-              <dataType>true</dataType>
-              <encoding>false</encoding>
-              <assertions>true</assertions>
-              <subresults>true</subresults>
-              <responseData>false</responseData>
-              <samplerData>false</samplerData>
-              <xml>false</xml>
-              <fieldNames>true</fieldNames>
-              <responseHeaders>false</responseHeaders>
-              <requestHeaders>false</requestHeaders>
-              <responseDataOnError>false</responseDataOnError>
-              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
-              <assertionsResultsToSave>0</assertionsResultsToSave>
-              <bytes>true</bytes>
-              <sentBytes>true</sentBytes>
-              <threadCounts>true</threadCounts>
-              <idleTime>true</idleTime>
-              <connectTime>true</connectTime>
-            </value>
-          </objProp>
-          <stringProp name="filename"></stringProp>
-        </ResultCollector>
+        <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Thread Delay" enabled="true">
+          <stringProp name="TestPlan.comments">Can be used to reduce the TPS. Ex: For long running tests.</stringProp>
+          <stringProp name="ConstantTimer.delay">${threadDelay}</stringProp>
+        </ConstantTimer>
         <hashTree/>
         <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>


### PR DESCRIPTION
### Proposed Changes
- Added a configurable thread delay to all test cases.
- Can be configured by adding below parameter to the JMeter command.
  ```-JthreadDelay=1000```
- Value is in milliseconds, and the default value is 0.
- This is helpful when we want to maintain a specific TPS value for a period of time. Ex: Long-running tests.