### PR TITLE
Add results of 5.11 GA single node performance tests to benchmarks

### DIFF
--- a/benchmarks/5.11.0/5.11.0_single-node_2-core.csv
+++ b/benchmarks/5.11.0/5.11.0_single-node_2-core.csv
@@ -1,0 +1,51 @@
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms)
+Authenticate Super Tenant User,50,1814.33,27.38
+Authenticate Super Tenant User,100,1780.4,55.97
+Authenticate Super Tenant User,150,1728.13,86.6
+Authenticate Super Tenant User,300,1680.79,178.28
+Authenticate Super Tenant User,500,1618.34,308.89
+Auth Code Grant Redirect With Consent,50,161.53,308.65
+Auth Code Grant Redirect With Consent,100,177.2,563.31
+Auth Code Grant Redirect With Consent,150,178.91,837.78
+Auth Code Grant Redirect With Consent,300,174.87,1715.19
+Auth Code Grant Redirect With Consent,500,176.14,2836.0
+Implicit Grant Redirect With Consent,50,252.61,197.27
+Implicit Grant Redirect With Consent,100,281.52,354.55
+Implicit Grant Redirect With Consent,150,292.19,512.88
+Implicit Grant Redirect With Consent,300,278.84,1075.76
+Implicit Grant Redirect With Consent,500,279.78,1786.12
+Password Grant Type,50,1420.59,35.03
+Password Grant Type,100,1443.31,69.11
+Password Grant Type,150,1418.62,105.55
+Password Grant Type,300,1009.39,297.14
+Password Grant Type,500,1301.89,384.06
+Client Credentials Grant Type,50,6880.12,7.08
+Client Credentials Grant Type,100,6880.98,14.33
+Client Credentials Grant Type,150,7229.84,20.53
+Client Credentials Grant Type,300,7085.55,42.08
+Client Credentials Grant Type,500,6770.34,73.54
+OIDC Auth Code Grant Redirect With Consent,50,152.5,327.0
+OIDC Auth Code Grant Redirect With Consent,100,177.2,563.37
+OIDC Auth Code Grant Redirect With Consent,150,184.47,812.57
+OIDC Auth Code Grant Redirect With Consent,300,182.01,1647.68
+OIDC Auth Code Grant Redirect With Consent,500,182.75,2733.63
+OIDC Implicit Grant Redirect With Consent,50,197.59,252.39
+OIDC Implicit Grant Redirect With Consent,100,219.41,455.13
+OIDC Implicit Grant Redirect With Consent,150,224.97,666.39
+OIDC Implicit Grant Redirect With Consent,300,220.02,1362.92
+OIDC Implicit Grant Redirect With Consent,500,219.66,2274.53
+OIDC Password Grant Type,50,616.23,80.97
+OIDC Password Grant Type,100,618.7,161.44
+OIDC Password Grant Type,150,561.17,267.22
+OIDC Password Grant Type,300,579.84,517.15
+OIDC Password Grant Type,500,573.59,870.76
+OIDC Auth Code Request Path Authenticator With Consent,50,157.69,316.56
+OIDC Auth Code Request Path Authenticator With Consent,100,199.59,500.91
+OIDC Auth Code Request Path Authenticator With Consent,150,203.97,735.26
+OIDC Auth Code Request Path Authenticator With Consent,300,202.41,1481.05
+OIDC Auth Code Request Path Authenticator With Consent,500,201.78,2472.96
+SAML2 SSO Redirect Binding,50,199.25,249.81
+SAML2 SSO Redirect Binding,100,206.59,482.96
+SAML2 SSO Redirect Binding,150,214.94,696.45
+SAML2 SSO Redirect Binding,300,218.6,1370.12
+SAML2 SSO Redirect Binding,500,200.31,2490.91

--- a/benchmarks/5.11.0/5.11.0_single-node_2-core.md
+++ b/benchmarks/5.11.0/5.11.0_single-node_2-core.md
@@ -1,0 +1,164 @@
+# IAM Performance Test Results
+
+During each release, we execute various automated performance test scenarios and publish the results.
+
+| Test Scenarios | Description |
+| --- | --- |
+| Authenticate Super Tenant User | Select random super tenant users and authenticate through the RemoteUserStoreManagerService. |
+| Auth Code Grant Redirect With Consent | Obtain an access token using the OAuth 2.0 authorization code grant type. |
+| Implicit Grant Redirect With Consent | Obtain an access token using the OAuth 2.0 implicit grant type. |
+| Password Grant Type | Obtain an access token using the OAuth 2.0 password grant type. |
+| Client Credentials Grant Type | Obtain an access token using the OAuth 2.0 client credential grant type. |
+| OIDC Auth Code Grant Redirect With Consent | Obtain an access token and an id token using the OAuth 2.0 authorization code grant type. |
+| OIDC Implicit Grant Redirect With Consent | Obtain an access token and an id token using the OAuth 2.0 implicit grant type. |
+| OIDC Password Grant Type | Obtain an access token and an id token using the OAuth 2.0 password grant type. |
+| OIDC Auth Code Request Path Authenticator With Consent | Obtain an access token and an id token using the request path authenticator. |
+| SAML2 SSO Redirect Binding | Obtain a SAML 2 assertion response using redirect binding. |
+
+Our test client is [Apache JMeter](https://jmeter.apache.org/index.html). We test each scenario for a fixed duration of
+time and split the test results into warm-up and measurement parts and use the measurement part to compute the
+performance metrics. For this particular instance, the duration of each test is **10 minutes** and the warm-up period is **2 minutes**.
+
+We run the performance tests under different numbers of concurrent users and heap sizes to gain a better understanding on how the server reacts to different loads.
+
+The main performance metrics:
+
+1. **Throughput**: The number of requests that the WSO2 Identity Server processes during a specific time interval (e.g. per second).
+2. **Response Time**: The end-to-end latency for a given operation of the WSO2 Identity Server. The complete distribution of response times was recorded.
+
+In addition to the above metrics, we measure the load average and several memory-related metrics.
+
+The following are the test parameters.
+
+| Test Parameter | Description | Values |
+| --- | --- | --- |
+| Scenario Name | The name of the test scenario. | Refer to the above table. |
+| Heap Size | The amount of memory allocated to the application | 2G |
+| Concurrent Users | The number of users accessing the application at the same time. | 50, 100, 150, 300, 500 |
+| IS Instance Type | The AWS instance type used to run the Identity Server. | [**c5.xlarge**](https://aws.amazon.com/ec2/instance-types/) |
+
+The following are the measurements collected from each performance test conducted for a given combination of
+test parameters.
+
+| Measurement | Description |
+| --- | --- |
+| Error % | Percentage of requests with errors |
+| Average Response Time (ms) | The average response time of a set of results |
+| Standard Deviation of Response Time (ms) | The Standard Deviation of the response time. |
+| 99th Percentile of Response Time (ms) | 99% of the requests took no more than this time. The remaining samples took at least as long as this |
+| Throughput (Requests/sec) | The throughput measured in requests per second. |
+| Average Memory Footprint After Full GC (M) | The average memory consumed by the application after a full garbage collection event. |
+
+The following is the summary of performance test results collected for the measurement period.
+
+
+
+**1. Authenticate Super Tenant User**
+
+Select random super tenant users and authenticate through the RemoteUserStoreManagerService.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 1814.33 | 27.38 |
+|  100 | 1780.4 | 55.97 |
+|  150 | 1728.13 | 86.6 |
+|  300 | 1680.79 | 178.28 |
+|  500 | 1618.34 | 308.89 |
+
+**2. Auth Code Grant Redirect With Consent**
+
+Obtain an access token using the OAuth 2.0 authorization code grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 161.53 | 308.65 |
+|  100 | 177.2 | 563.31 |
+|  150 | 178.91 | 837.78 |
+|  300 | 174.87 | 1715.19 |
+|  500 | 176.14 | 2836.0 |
+
+**3. Implicit Grant Redirect With Consent**
+
+Obtain an access token using the OAuth 2.0 implicit grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 252.61 | 197.27 |
+|  100 | 281.52 | 354.55 |
+|  150 | 292.19 | 512.88 |
+|  300 | 278.84 | 1075.76 |
+|  500 | 279.78 | 1786.12 |
+
+**4. Password Grant Type**
+
+Obtain an access token using the OAuth 2.0 password grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 1420.59 | 35.03 |
+|  100 | 1443.31 | 69.11 |
+|  150 | 1418.62 | 105.55 |
+|  300 | 1009.39 | 297.14 |
+|  500 | 1301.89 | 384.06 |
+
+**5. Client Credentials Grant Type**
+
+Obtain an access token using the OAuth 2.0 client credential grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 6880.12 | 7.08 |
+|  100 | 6880.98 | 14.33 |
+|  150 | 7229.84 | 20.53 |
+|  300 | 7085.55 | 42.08 |
+|  500 | 6770.34 | 73.54 |
+
+**6. OIDC Auth Code Grant Redirect With Consent**
+
+Obtain an access token and an id token using the OAuth 2.0 authorization code grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 152.5 | 327.0 |
+|  100 | 177.2 | 563.37 |
+|  150 | 184.47 | 812.57 |
+|  300 | 182.01 | 1647.68 |
+|  500 | 182.75 | 2733.63 |
+
+**7. OIDC Implicit Grant Redirect With Consent**
+
+Obtain an access token and an id token using the OAuth 2.0 implicit grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 197.59 | 252.39 |
+|  100 | 219.41 | 455.13 |
+|  150 | 224.97 | 666.39 |
+|  300 | 220.02 | 1362.92 |
+|  500 | 219.66 | 2274.53 |
+
+**8. OIDC Password Grant Type**
+
+Obtain an access token and an id token using the OAuth 2.0 password grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 616.23 | 80.97 |
+|  100 | 618.7 | 161.44 |
+|  150 | 561.17 | 267.22 |
+|  300 | 579.84 | 517.15 |
+|  500 | 573.59 | 870.76 |
+
+**9. OIDC Auth Code Request Path Authenticator With Consent**
+
+Obtain an access token and an id token using the request path authenticator.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 157.69 | 316.56 |
+|  100 | 199.59 | 500.91 |
+|  150 | 203.97 | 735.26 |
+|  300 | 202.41 | 1481.05 |
+|  500 | 201.78 | 2472.96 |
+
+**10. SAML2 SSO Redirect Binding**
+
+Obtain a SAML 2 assertion response using redirect binding.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 199.25 | 249.81 |
+|  100 | 206.59 | 482.96 |
+|  150 | 214.94 | 696.45 |
+|  300 | 218.6 | 1370.12 |
+|  500 | 200.31 | 2490.91 |

--- a/benchmarks/5.11.0/5.11.0_single-node_4-core.csv
+++ b/benchmarks/5.11.0/5.11.0_single-node_4-core.csv
@@ -1,0 +1,51 @@
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms)
+Authenticate Super Tenant User,50,1854.69,26.78
+Authenticate Super Tenant User,100,1803.8,55.24
+Authenticate Super Tenant User,150,1760.41,85.0
+Authenticate Super Tenant User,300,1682.89,178.1
+Authenticate Super Tenant User,500,1618.04,308.95
+Auth Code Grant Redirect With Consent,50,155.36,320.91
+Auth Code Grant Redirect With Consent,100,180.28,553.66
+Auth Code Grant Redirect With Consent,150,183.21,818.09
+Auth Code Grant Redirect With Consent,300,181.43,1653.3
+Auth Code Grant Redirect With Consent,500,182.55,2736.81
+Implicit Grant Redirect With Consent,50,252.94,196.99
+Implicit Grant Redirect With Consent,100,291.93,341.86
+Implicit Grant Redirect With Consent,150,297.99,502.86
+Implicit Grant Redirect With Consent,300,282.84,1060.48
+Implicit Grant Redirect With Consent,500,296.68,1684.87
+Password Grant Type,50,1422.25,34.99
+Password Grant Type,100,1445.14,69.02
+Password Grant Type,150,1428.56,104.81
+Password Grant Type,300,1342.81,223.27
+Password Grant Type,500,1346.03,371.43
+Client Credentials Grant Type,50,7271.12,6.65
+Client Credentials Grant Type,100,7014.36,13.99
+Client Credentials Grant Type,150,7304.77,20.34
+Client Credentials Grant Type,300,7165.18,41.56
+Client Credentials Grant Type,500,7053.27,70.49
+OIDC Auth Code Grant Redirect With Consent,50,150.36,331.63
+OIDC Auth Code Grant Redirect With Consent,100,178.97,557.78
+OIDC Auth Code Grant Redirect With Consent,150,182.11,823.11
+OIDC Auth Code Grant Redirect With Consent,300,180.63,1660.29
+OIDC Auth Code Grant Redirect With Consent,500,180.25,2771.24
+OIDC Implicit Grant Redirect With Consent,50,197.39,252.61
+OIDC Implicit Grant Redirect With Consent,100,222.16,449.5
+OIDC Implicit Grant Redirect With Consent,150,229.81,652.41
+OIDC Implicit Grant Redirect With Consent,300,224.84,1333.82
+OIDC Implicit Grant Redirect With Consent,500,226.86,2201.93
+OIDC Password Grant Type,50,610.13,81.77
+OIDC Password Grant Type,100,600.01,166.45
+OIDC Password Grant Type,150,601.53,249.29
+OIDC Password Grant Type,300,582.81,514.51
+OIDC Password Grant Type,500,592.85,842.19
+OIDC Auth Code Request Path Authenticator With Consent,50,160.43,311.13
+OIDC Auth Code Request Path Authenticator With Consent,100,190.71,524.19
+OIDC Auth Code Request Path Authenticator With Consent,150,203.48,737.03
+OIDC Auth Code Request Path Authenticator With Consent,300,188.46,1590.17
+OIDC Auth Code Request Path Authenticator With Consent,500,190.97,2613.14
+SAML2 SSO Redirect Binding,50,208.37,238.79
+SAML2 SSO Redirect Binding,100,215.12,463.9
+SAML2 SSO Redirect Binding,150,221.52,676.02
+SAML2 SSO Redirect Binding,300,218.98,1367.85
+SAML2 SSO Redirect Binding,500,206.51,2414.51

--- a/benchmarks/5.11.0/5.11.0_single-node_4-core.md
+++ b/benchmarks/5.11.0/5.11.0_single-node_4-core.md
@@ -1,0 +1,164 @@
+# IAM Performance Test Results
+
+During each release, we execute various automated performance test scenarios and publish the results.
+
+| Test Scenarios | Description |
+| --- | --- |
+| Authenticate Super Tenant User | Select random super tenant users and authenticate through the RemoteUserStoreManagerService. |
+| Auth Code Grant Redirect With Consent | Obtain an access token using the OAuth 2.0 authorization code grant type. |
+| Implicit Grant Redirect With Consent | Obtain an access token using the OAuth 2.0 implicit grant type. |
+| Password Grant Type | Obtain an access token using the OAuth 2.0 password grant type. |
+| Client Credentials Grant Type | Obtain an access token using the OAuth 2.0 client credential grant type. |
+| OIDC Auth Code Grant Redirect With Consent | Obtain an access token and an id token using the OAuth 2.0 authorization code grant type. |
+| OIDC Implicit Grant Redirect With Consent | Obtain an access token and an id token using the OAuth 2.0 implicit grant type. |
+| OIDC Password Grant Type | Obtain an access token and an id token using the OAuth 2.0 password grant type. |
+| OIDC Auth Code Request Path Authenticator With Consent | Obtain an access token and an id token using the request path authenticator. |
+| SAML2 SSO Redirect Binding | Obtain a SAML 2 assertion response using redirect binding. |
+
+Our test client is [Apache JMeter](https://jmeter.apache.org/index.html). We test each scenario for a fixed duration of
+time and split the test results into warm-up and measurement parts and use the measurement part to compute the
+performance metrics. For this particular instance, the duration of each test is **10 minutes** and the warm-up period is **2 minutes**.
+
+We run the performance tests under different numbers of concurrent users and heap sizes to gain a better understanding on how the server reacts to different loads.
+
+The main performance metrics:
+
+1. **Throughput**: The number of requests that the WSO2 Identity Server processes during a specific time interval (e.g. per second).
+2. **Response Time**: The end-to-end latency for a given operation of the WSO2 Identity Server. The complete distribution of response times was recorded.
+
+In addition to the above metrics, we measure the load average and several memory-related metrics.
+
+The following are the test parameters.
+
+| Test Parameter | Description | Values |
+| --- | --- | --- |
+| Scenario Name | The name of the test scenario. | Refer to the above table. |
+| Heap Size | The amount of memory allocated to the application | 2G |
+| Concurrent Users | The number of users accessing the application at the same time. | 50, 100, 150, 300, 500 |
+| IS Instance Type | The AWS instance type used to run the Identity Server. | [**c5.xlarge**](https://aws.amazon.com/ec2/instance-types/) |
+
+The following are the measurements collected from each performance test conducted for a given combination of
+test parameters.
+
+| Measurement | Description |
+| --- | --- |
+| Error % | Percentage of requests with errors |
+| Average Response Time (ms) | The average response time of a set of results |
+| Standard Deviation of Response Time (ms) | The Standard Deviation of the response time. |
+| 99th Percentile of Response Time (ms) | 99% of the requests took no more than this time. The remaining samples took at least as long as this |
+| Throughput (Requests/sec) | The throughput measured in requests per second. |
+| Average Memory Footprint After Full GC (M) | The average memory consumed by the application after a full garbage collection event. |
+
+The following is the summary of performance test results collected for the measurement period.
+
+
+
+**1. Authenticate Super Tenant User**
+
+Select random super tenant users and authenticate through the RemoteUserStoreManagerService.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 1854.69 | 26.78 |
+|  100 | 1803.8 | 55.24 |
+|  150 | 1760.41 | 85.0 |
+|  300 | 1682.89 | 178.1 |
+|  500 | 1618.04 | 308.95 |
+
+**2. Auth Code Grant Redirect With Consent**
+
+Obtain an access token using the OAuth 2.0 authorization code grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 155.36 | 320.91 |
+|  100 | 180.28 | 553.66 |
+|  150 | 183.21 | 818.09 |
+|  300 | 181.43 | 1653.3 |
+|  500 | 182.55 | 2736.81 |
+
+**3. Implicit Grant Redirect With Consent**
+
+Obtain an access token using the OAuth 2.0 implicit grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 252.94 | 196.99 |
+|  100 | 291.93 | 341.86 |
+|  150 | 297.99 | 502.86 |
+|  300 | 282.84 | 1060.48 |
+|  500 | 296.68 | 1684.87 |
+
+**4. Password Grant Type**
+
+Obtain an access token using the OAuth 2.0 password grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 1422.25 | 34.99 |
+|  100 | 1445.14 | 69.02 |
+|  150 | 1428.56 | 104.81 |
+|  300 | 1342.81 | 223.27 |
+|  500 | 1346.03 | 371.43 |
+
+**5. Client Credentials Grant Type**
+
+Obtain an access token using the OAuth 2.0 client credential grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 7271.12 | 6.65 |
+|  100 | 7014.36 | 13.99 |
+|  150 | 7304.77 | 20.34 |
+|  300 | 7165.18 | 41.56 |
+|  500 | 7053.27 | 70.49 |
+
+**6. OIDC Auth Code Grant Redirect With Consent**
+
+Obtain an access token and an id token using the OAuth 2.0 authorization code grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 150.36 | 331.63 |
+|  100 | 178.97 | 557.78 |
+|  150 | 182.11 | 823.11 |
+|  300 | 180.63 | 1660.29 |
+|  500 | 180.25 | 2771.24 |
+
+**7. OIDC Implicit Grant Redirect With Consent**
+
+Obtain an access token and an id token using the OAuth 2.0 implicit grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 197.39 | 252.61 |
+|  100 | 222.16 | 449.5 |
+|  150 | 229.81 | 652.41 |
+|  300 | 224.84 | 1333.82 |
+|  500 | 226.86 | 2201.93 |
+
+**8. OIDC Password Grant Type**
+
+Obtain an access token and an id token using the OAuth 2.0 password grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 610.13 | 81.77 |
+|  100 | 600.01 | 166.45 |
+|  150 | 601.53 | 249.29 |
+|  300 | 582.81 | 514.51 |
+|  500 | 592.85 | 842.19 |
+
+**9. OIDC Auth Code Request Path Authenticator With Consent**
+
+Obtain an access token and an id token using the request path authenticator.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 160.43 | 311.13 |
+|  100 | 190.71 | 524.19 |
+|  150 | 203.48 | 737.03 |
+|  300 | 188.46 | 1590.17 |
+|  500 | 190.97 | 2613.14 |
+
+**10. SAML2 SSO Redirect Binding**
+
+Obtain a SAML 2 assertion response using redirect binding.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 208.37 | 238.79 |
+|  100 | 215.12 | 463.9 |
+|  150 | 221.52 | 676.02 |
+|  300 | 218.98 | 1367.85 |
+|  500 | 206.51 | 2414.51 |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,7 +22,8 @@ Server version | Deployment | Updated on | IS Instance Type | RDS Instance Type 
 5.10.0 WUM (1600099543376) | Single node | 2020/09/21 | c5.xlarge (4 core) | db.m4.xlarge | [:arrow_upper_right:](5.10.0/WUM/1600099543376/5.10.0_single-node_4-core.md)
 5.10.0 WUM (1600099543376) | 2-node cluster | 2020/09/21 | c5.large (2 core) | db.m4.xlarge | [:arrow_upper_right:](5.10.0/WUM/1600099543376/5.10.0_two-nodes_2-core.md)
 5.10.0 WUM (1600099543376) | Single node | 2020/09/21 | c5.large (2 core) | db.m4.xlarge | [:arrow_upper_right:](5.10.0/WUM/1600099543376/5.10.0_single-node_2-core.md)
-
+5.11.0 GA | Single node | 2020/12/23 | c5.xlarge (4 core) | db.m4.xlarge | [:arrow_upper_right:](5.11.0/5.11.0_single-node_4-core.md)
+5.11.0 GA | Single node | 2020/12/23 | c5.large (2 core) | db.m4.xlarge | [:arrow_upper_right:](5.11.0/5.11.0_single-node_2-core.md)
 
 ### Deployment Diagram - Single node
 ![Deployment Diagram - Single node](https://github.com/wso2/performance-is/blob/master/common/images/deployment-diagram-singlenode.png)


### PR DESCRIPTION
## Purpose
Add performance test results for 5.11 GA single node performance tests to benchmarks
Related to : https://github.com/wso2/product-is/issues/8976