### PR TITLE
Add results of 5.11 GA 2 node cluster (4 core) performance tests to benchmarks

### DIFF
--- a/benchmarks/5.11.0/5.11.0_two-nodes_4-core.csv
+++ b/benchmarks/5.11.0/5.11.0_two-nodes_4-core.csv
@@ -1,0 +1,51 @@
+Scenario Name,Concurrent Users,Throughput (Requests/sec),Average Response Time (ms)
+Authenticate Super Tenant User,50,1787.25,27.79
+Authenticate Super Tenant User,100,1809.8,55.06
+Authenticate Super Tenant User,150,1765.59,84.76
+Authenticate Super Tenant User,300,1769.97,169.32
+Authenticate Super Tenant User,500,1745.29,286.3
+Auth Code Grant Redirect With Consent,50,167.03,298.42
+Auth Code Grant Redirect With Consent,100,184.36,541.39
+Auth Code Grant Redirect With Consent,150,180.7,829.4
+Auth Code Grant Redirect With Consent,300,175.02,1713.77
+Auth Code Grant Redirect With Consent,500,170.19,2935.86
+Implicit Grant Redirect With Consent,50,264.83,188.1
+Implicit Grant Redirect With Consent,100,305.62,326.43
+Implicit Grant Redirect With Consent,150,326.83,458.25
+Implicit Grant Redirect With Consent,300,320.5,935.54
+Implicit Grant Redirect With Consent,500,307.41,1626.01
+Password Grant Type,50,1444.86,34.41
+Password Grant Type,100,1482.67,67.24
+Password Grant Type,150,1465.25,102.15
+Password Grant Type,300,1432.7,209.24
+Password Grant Type,500,1392.47,358.89
+Client Credentials Grant Type,50,5467.1,8.95
+Client Credentials Grant Type,100,5863.24,16.83
+Client Credentials Grant Type,150,6115.26,24.28
+Client Credentials Grant Type,300,6319.69,47.17
+Client Credentials Grant Type,500,6405.64,77.7
+OIDC Auth Code Grant Redirect With Consent,50,155.38,320.85
+OIDC Auth Code Grant Redirect With Consent,100,182.81,545.97
+OIDC Auth Code Grant Redirect With Consent,150,182.28,822.22
+OIDC Auth Code Grant Redirect With Consent,300,173.95,1724.38
+OIDC Auth Code Grant Redirect With Consent,500,170.7,2926.12
+OIDC Implicit Grant Redirect With Consent,50,180.28,276.69
+OIDC Implicit Grant Redirect With Consent,100,185.48,538.63
+OIDC Implicit Grant Redirect With Consent,150,191.57,782.78
+OIDC Implicit Grant Redirect With Consent,300,183.72,1632.33
+OIDC Implicit Grant Redirect With Consent,500,184.94,2700.34
+OIDC Password Grant Type,50,756.64,65.91
+OIDC Password Grant Type,100,767.99,130.02
+OIDC Password Grant Type,150,757.85,197.75
+OIDC Password Grant Type,300,741.56,404.54
+OIDC Password Grant Type,500,708.97,704.84
+OIDC Auth Code Request Path Authenticator With Consent,50,156.49,319.06
+OIDC Auth Code Request Path Authenticator With Consent,100,190.86,523.77
+OIDC Auth Code Request Path Authenticator With Consent,150,189.76,790.34
+OIDC Auth Code Request Path Authenticator With Consent,300,182.6,1641.6
+OIDC Auth Code Request Path Authenticator With Consent,500,176.45,2828.36
+SAML2 SSO Redirect Binding,50,230.5,215.69
+SAML2 SSO Redirect Binding,100,263.03,379.07
+SAML2 SSO Redirect Binding,150,287.47,520.63
+SAML2 SSO Redirect Binding,300,320.31,934.44
+SAML2 SSO Redirect Binding,500,317.12,1574.46

--- a/benchmarks/5.11.0/5.11.0_two-nodes_4-core.md
+++ b/benchmarks/5.11.0/5.11.0_two-nodes_4-core.md
@@ -1,0 +1,164 @@
+# IAM Performance Test Results
+
+During each release, we execute various automated performance test scenarios and publish the results.
+
+| Test Scenarios | Description |
+| --- | --- |
+| Authenticate Super Tenant User | Select random super tenant users and authenticate through the RemoteUserStoreManagerService. |
+| Auth Code Grant Redirect With Consent | Obtain an access token using the OAuth 2.0 authorization code grant type. |
+| Implicit Grant Redirect With Consent | Obtain an access token using the OAuth 2.0 implicit grant type. |
+| Password Grant Type | Obtain an access token using the OAuth 2.0 password grant type. |
+| Client Credentials Grant Type | Obtain an access token using the OAuth 2.0 client credential grant type. |
+| OIDC Auth Code Grant Redirect With Consent | Obtain an access token and an id token using the OAuth 2.0 authorization code grant type. |
+| OIDC Implicit Grant Redirect With Consent | Obtain an access token and an id token using the OAuth 2.0 implicit grant type. |
+| OIDC Password Grant Type | Obtain an access token and an id token using the OAuth 2.0 password grant type. |
+| OIDC Auth Code Request Path Authenticator With Consent | Obtain an access token and an id token using the request path authenticator. |
+| SAML2 SSO Redirect Binding | Obtain a SAML 2 assertion response using redirect binding. |
+
+Our test client is [Apache JMeter](https://jmeter.apache.org/index.html). We test each scenario for a fixed duration of
+time and split the test results into warm-up and measurement parts and use the measurement part to compute the
+performance metrics. For this particular instance, the duration of each test is **10 minutes** and the warm-up period is **2 minutes**.
+
+We run the performance tests under different numbers of concurrent users and heap sizes to gain a better understanding on how the server reacts to different loads.
+
+The main performance metrics:
+
+1. **Throughput**: The number of requests that the WSO2 Identity Server processes during a specific time interval (e.g. per second).
+2. **Response Time**: The end-to-end latency for a given operation of the WSO2 Identity Server. The complete distribution of response times was recorded.
+
+In addition to the above metrics, we measure the load average and several memory-related metrics.
+
+The following are the test parameters.
+
+| Test Parameter | Description | Values |
+| --- | --- | --- |
+| Scenario Name | The name of the test scenario. | Refer to the above table. |
+| Heap Size | The amount of memory allocated to the application | 2G |
+| Concurrent Users | The number of users accessing the application at the same time. | 50, 100, 150, 300, 500 |
+| IS Instance Type | The AWS instance type used to run the Identity Server. | [**c5.xlarge**](https://aws.amazon.com/ec2/instance-types/) |
+
+The following are the measurements collected from each performance test conducted for a given combination of
+test parameters.
+
+| Measurement | Description |
+| --- | --- |
+| Error % | Percentage of requests with errors |
+| Average Response Time (ms) | The average response time of a set of results |
+| Standard Deviation of Response Time (ms) | The Standard Deviation of the response time. |
+| 99th Percentile of Response Time (ms) | 99% of the requests took no more than this time. The remaining samples took at least as long as this |
+| Throughput (Requests/sec) | The throughput measured in requests per second. |
+| Average Memory Footprint After Full GC (M) | The average memory consumed by the application after a full garbage collection event. |
+
+The following is the summary of performance test results collected for the measurement period.
+
+
+
+**1. Authenticate Super Tenant User**
+
+Select random super tenant users and authenticate through the RemoteUserStoreManagerService.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 1787.25 | 27.79 |
+|  100 | 1809.8 | 55.06 |
+|  150 | 1765.59 | 84.76 |
+|  300 | 1769.97 | 169.32 |
+|  500 | 1745.29 | 286.3 |
+
+**2. Auth Code Grant Redirect With Consent**
+
+Obtain an access token using the OAuth 2.0 authorization code grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 167.03 | 298.42 |
+|  100 | 184.36 | 541.39 |
+|  150 | 180.7 | 829.4 |
+|  300 | 175.02 | 1713.77 |
+|  500 | 170.19 | 2935.86 |
+
+**3. Implicit Grant Redirect With Consent**
+
+Obtain an access token using the OAuth 2.0 implicit grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 264.83 | 188.1 |
+|  100 | 305.62 | 326.43 |
+|  150 | 326.83 | 458.25 |
+|  300 | 320.5 | 935.54 |
+|  500 | 307.41 | 1626.01 |
+
+**4. Password Grant Type**
+
+Obtain an access token using the OAuth 2.0 password grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 1444.86 | 34.41 |
+|  100 | 1482.67 | 67.24 |
+|  150 | 1465.25 | 102.15 |
+|  300 | 1432.7 | 209.24 |
+|  500 | 1392.47 | 358.89 |
+
+**5. Client Credentials Grant Type**
+
+Obtain an access token using the OAuth 2.0 client credential grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 5467.1 | 8.95 |
+|  100 | 5863.24 | 16.83 |
+|  150 | 6115.26 | 24.28 |
+|  300 | 6319.69 | 47.17 |
+|  500 | 6405.64 | 77.7 |
+
+**6. OIDC Auth Code Grant Redirect With Consent**
+
+Obtain an access token and an id token using the OAuth 2.0 authorization code grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 155.38 | 320.85 |
+|  100 | 182.81 | 545.97 |
+|  150 | 182.28 | 822.22 |
+|  300 | 173.95 | 1724.38 |
+|  500 | 170.7 | 2926.12 |
+
+**7. OIDC Implicit Grant Redirect With Consent**
+
+Obtain an access token and an id token using the OAuth 2.0 implicit grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 180.28 | 276.69 |
+|  100 | 185.48 | 538.63 |
+|  150 | 191.57 | 782.78 |
+|  300 | 183.72 | 1632.33 |
+|  500 | 184.94 | 2700.34 |
+
+**8. OIDC Password Grant Type**
+
+Obtain an access token and an id token using the OAuth 2.0 password grant type.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 756.64 | 65.91 |
+|  100 | 767.99 | 130.02 |
+|  150 | 757.85 | 197.75 |
+|  300 | 741.56 | 404.54 |
+|  500 | 708.97 | 704.84 |
+
+**9. OIDC Auth Code Request Path Authenticator With Consent**
+
+Obtain an access token and an id token using the request path authenticator.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 156.49 | 319.06 |
+|  100 | 190.86 | 523.77 |
+|  150 | 189.76 | 790.34 |
+|  300 | 182.6 | 1641.6 |
+|  500 | 176.45 | 2828.36 |
+
+**10. SAML2 SSO Redirect Binding**
+
+Obtain a SAML 2 assertion response using redirect binding.
+|  Concurrent Users | Throughput (Requests/sec) | Average Response Time (ms) |
+|---|---:|---:|
+|  50 | 230.5 | 215.69 |
+|  100 | 263.03 | 379.07 |
+|  150 | 287.47 | 520.63 |
+|  300 | 320.31 | 934.44 |
+|  500 | 317.12 | 1574.46 |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,7 @@ Server version | Deployment | Updated on | IS Instance Type | RDS Instance Type 
 5.10.0 WUM (1600099543376) | Single node | 2020/09/21 | c5.large (2 core) | db.m4.xlarge | [:arrow_upper_right:](5.10.0/WUM/1600099543376/5.10.0_single-node_2-core.md)
 5.11.0 GA | Single node | 2020/12/23 | c5.xlarge (4 core) | db.m4.xlarge | [:arrow_upper_right:](5.11.0/5.11.0_single-node_4-core.md)
 5.11.0 GA | Single node | 2020/12/23 | c5.large (2 core) | db.m4.xlarge | [:arrow_upper_right:](5.11.0/5.11.0_single-node_2-core.md)
+5.11.0 GA | 2-node cluster | 2021/01/02 | c5.xlarge (4 core) | db.m4.xlarge | [:arrow_upper_right:](5.11.0/5.11.0_two-nodes_4-core.md)
 
 ### Deployment Diagram - Single node
 ![Deployment Diagram - Single node](https://github.com/wso2/performance-is/blob/master/common/images/deployment-diagram-singlenode.png)


### PR DESCRIPTION
Add performance test results for 5.11 GA two nodes cluster (4 core) performance tests to benchmarks
Related to : https://github.com/wso2/product-is/issues/8976