### PR TITLE
Add random delay to the test plan for user input in the authentication process

### DIFF
--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC- Authorization Code Redirect With Consent" enabled="true">
       <stringProp name="TestPlan.comments">Login to </stringProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC- Authorization Code Redirect With Consent" enabled="true">
       <stringProp name="TestPlan.comments">Login to </stringProp>
@@ -302,6 +302,16 @@ if (y == 0) {
             <stringProp name="Assertion.custom_message">Test failed - authorize end poiont</stringProp>
           </ResponseAssertion>
           <hashTree/>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Redirect URL Extractor" enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">true</stringProp>
+            <stringProp name="RegexExtractor.refname">redirectURL</stringProp>
+            <stringProp name="RegexExtractor.regex">Location:\s*https:\/\/[^\s]*\/(authenticationendpoint\/login\.do.*)</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">NF</stringProp>
+            <stringProp name="RegexExtractor.match_number">1</stringProp>
+            <stringProp name="Sample.scope">all</stringProp>
+          </RegexExtractor>
+          <hashTree/>
           <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regular Expression Extractor" enabled="true">
             <stringProp name="RegexExtractor.useHeaders">true</stringProp>
             <stringProp name="RegexExtractor.refname">sessionDataKey</stringProp>
@@ -354,6 +364,11 @@ if (y == 0) {
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="RandomTimer.range">2000</stringProp>
+          </GaussianRandomTimer>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103172738">HTTP/1.1 302</stringProp>
@@ -500,6 +515,11 @@ ${password}</stringProp>
             <stringProp name="HTTPSampler.response_timeout"></stringProp>
           </HTTPSamplerProxy>
           <hashTree>
+            <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+              <stringProp name="ConstantTimer.delay">2000</stringProp>
+              <stringProp name="RandomTimer.range">1000</stringProp>
+            </GaussianRandomTimer>
+            <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
               <collectionProp name="Asserion.test_strings">
                 <stringProp name="103172738">HTTP/1.1 302</stringProp>

--- a/common/jmeter/oidc/OIDC_Password_Grant.jmx
+++ b/common/jmeter/oidc/OIDC_Password_Grant.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC - Password Grant Type" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>
@@ -296,6 +296,11 @@ if (y == 0) {
           <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="RandomTimer.range">2000</stringProp>
+          </GaussianRandomTimer>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>

--- a/common/jmeter/oidc/OIDC_Password_Grant.jmx
+++ b/common/jmeter/oidc/OIDC_Password_Grant.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC - Password Grant Type" enabled="true">
       <stringProp name="TestPlan.comments"></stringProp>

--- a/common/jmeter/oidc/OIDC_Password_Grant.jmx
+++ b/common/jmeter/oidc/OIDC_Password_Grant.jmx
@@ -296,11 +296,6 @@ if (y == 0) {
           <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
-          </GaussianRandomTimer>
-          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>

--- a/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
+++ b/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="SAML2 SSO Redirect Binding" enabled="true">
       <stringProp name="TestPlan.comments">This is a Jmeter test to the SAML 2.0 SSO functionality.</stringProp>

--- a/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
+++ b/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="SAML2 SSO Redirect Binding" enabled="true">
       <stringProp name="TestPlan.comments">This is a Jmeter test to the SAML 2.0 SSO functionality.</stringProp>
@@ -338,7 +338,7 @@ sessionDataKey=([a-z0-9-]+)\&amp;?</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
               </elementProp>
-	          <elementProp name="tocommonauth" elementType="HTTPArgument">
+              <elementProp name="tocommonauth" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">true</boolProp>
                 <stringProp name="Argument.name">tocommonauth</stringProp>
                 <stringProp name="Argument.value">true</stringProp>
@@ -368,6 +368,11 @@ ${password}
 </stringProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="RandomTimer.range">2000</stringProp>
+          </GaussianRandomTimer>
+          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP 200" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>

--- a/single-node/run-performance-tests.sh
+++ b/single-node/run-performance-tests.sh
@@ -37,7 +37,7 @@ declare -A test_scenario0=(
     [jmx]="authenticate/Authenticate_Super_Tenant_User.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL"
+    [modes]="FULL QUICK"
 )
 declare -A test_scenario1=(
     [name]="01-oauth_auth_code_redirect_with_consent"
@@ -73,7 +73,7 @@ declare -A test_scenario4=(
     [jmx]="oauth/OAuth_Client_Credentials_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL"
 )
 declare -A test_scenario5=(
     [name]="05-oidc_auth_code_redirect_with_consent"
@@ -226,7 +226,7 @@ declare -A test_scenario21=(
     [jmx]="oauth/OAuth_Jwt_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK JWT_GRANT_FLOW"
+    [modes]="FULL JWT_GRANT_FLOW"
 )
 declare -A test_scenario22=(
     [name]="22-oauth_jwt_grant_tenant"

--- a/single-node/run-performance-tests.sh
+++ b/single-node/run-performance-tests.sh
@@ -37,7 +37,7 @@ declare -A test_scenario0=(
     [jmx]="authenticate/Authenticate_Super_Tenant_User.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL"
 )
 declare -A test_scenario1=(
     [name]="01-oauth_auth_code_redirect_with_consent"
@@ -73,7 +73,7 @@ declare -A test_scenario4=(
     [jmx]="oauth/OAuth_Client_Credentials_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL"
+    [modes]="FULL QUICK"
 )
 declare -A test_scenario5=(
     [name]="05-oidc_auth_code_redirect_with_consent"
@@ -226,7 +226,7 @@ declare -A test_scenario21=(
     [jmx]="oauth/OAuth_Jwt_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL JWT_GRANT_FLOW"
+    [modes]="FULL QUICK JWT_GRANT_FLOW"
 )
 declare -A test_scenario22=(
     [name]="22-oauth_jwt_grant_tenant"

--- a/single-node/run-performance-tests.sh
+++ b/single-node/run-performance-tests.sh
@@ -73,7 +73,7 @@ declare -A test_scenario4=(
     [jmx]="oauth/OAuth_Client_Credentials_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL"
+    [modes]="FULL PUBLISH"
 )
 declare -A test_scenario5=(
     [name]="05-oidc_auth_code_redirect_with_consent"
@@ -82,7 +82,7 @@ declare -A test_scenario5=(
     [jmx]="oidc/OIDC_AuthCode_Redirect_WithConsent.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL QUICK PUBLISH"
 )
 declare -A test_scenario6=(
     [name]="06-oidc_implicit_redirect_with_consent"
@@ -100,7 +100,7 @@ declare -A test_scenario7=(
     [jmx]="oidc/OIDC_Password_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL QUICK PUBLISH"
 )
 declare -A test_scenario8=(
     [name]="08-oidc_request_path_authenticator"
@@ -118,7 +118,7 @@ declare -A test_scenario9=(
     [jmx]="saml/SAML2_SSO_Redirect_Binding.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL QUICK PUBLISH"
 )
 declare -A test_scenario10=(
     [name]="10-oauth_auth_code_redirect_with_consent_tenant"
@@ -202,22 +202,22 @@ declare -A test_scenario18=(
     [modes]="FULL"
 )
 declare -A test_scenario19=(
-    [name]="19-oidc_device_code_grant"
-    [display_name]="Device Code Grant Flow"
-    [description]="Obtain an access token using the OAuth 2.0 device code grant type."
-    [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
-    [tenantMode]=false
-    [skip]=false
-    [modes]="FULL DEVICE_FLOW"
+  [name]="19-oidc_device_code_grant"
+  [display_name]="Device Code Grant Flow"
+  [description]="Obtain an access token using the OAuth 2.0 device code grant type."
+  [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
+  [tenantMode]=false
+  [skip]=false
+  [modes]="FULL DEVICE_FLOW"
 )
 declare -A test_scenario20=(
-    [name]="20-oidc_device_code_grant_tenant"
-    [display_name]="Device Code Grant Flow"
-    [description]="Obtain an access token using the OAuth 2.0 device code grant type."
-    [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
-    [tenantMode]=false
-    [skip]=true
-    [modes]="FULL DEVICE_FLOW"
+  [name]="20-oidc_device_code_grant_tenant"
+  [display_name]="Device Code Grant Flow"
+  [description]="Obtain an access token using the OAuth 2.0 device code grant type."
+  [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
+  [tenantMode]=true
+  [skip]=true
+  [modes]="FULL DEVICE_FLOW"
 )
 declare -A test_scenario21=(
     [name]="21-oauth_jwt_grant_tenant"
@@ -226,7 +226,7 @@ declare -A test_scenario21=(
     [jmx]="oauth/OAuth_Jwt_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL JWT_GRANT_FLOW"
+    [modes]="FULL JWT_GRANT_FLOW PUBLISH"
 )
 declare -A test_scenario22=(
     [name]="22-oauth_jwt_grant_tenant"

--- a/two-node-cluster/run-performance-tests.sh
+++ b/two-node-cluster/run-performance-tests.sh
@@ -38,7 +38,7 @@ declare -A test_scenario0=(
     [jmx]="authenticate/Authenticate_Super_Tenant_User.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL"
+    [modes]="FULL QUICK"
 )
 declare -A test_scenario1=(
     [name]="01-oauth_auth_code_redirect_with_consent"
@@ -74,7 +74,7 @@ declare -A test_scenario4=(
     [jmx]="oauth/OAuth_Client_Credentials_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL"
 )
 declare -A test_scenario5=(
     [name]="05-oidc_auth_code_redirect_with_consent"
@@ -203,22 +203,22 @@ declare -A test_scenario18=(
     [modes]="FULL"
 )
 declare -A test_scenario19=(
-    [name]="19-oidc_device_code_grant"
-    [display_name]="Device Code Grant Flow"
-    [description]="Obtain an access token using the OAuth 2.0 device code grant type."
-    [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
-    [tenantMode]=false
-    [skip]=false
-    [modes]="FULL DEVICE_FLOW"
+  [name]="19-oidc_device_code_grant"
+  [display_name]="Device Code Grant Flow"
+  [description]="Obtain an access token using the OAuth 2.0 device code grant type."
+  [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
+  [tenantMode]=false
+  [skip]=false
+  [modes]="FULL DEVICE_FLOW"
 )
 declare -A test_scenario20=(
-    [name]="20-oidc_device_code_grant_tenant"
-    [display_name]="Device Code Grant Flow"
-    [description]="Obtain an access token using the OAuth 2.0 device code grant type."
-    [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
-    [tenantMode]=false
-    [skip]=true
-    [modes]="FULL DEVICE_FLOW"
+  [name]="20-oidc_device_code_grant_tenant"
+  [display_name]="Device Code Grant Flow"
+  [description]="Obtain an access token using the OAuth 2.0 device code grant type."
+  [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
+  [tenantMode]=true
+  [skip]=true
+  [modes]="FULL DEVICE_FLOW"
 )
 declare -A test_scenario21=(
     [name]="21-oauth_jwt_grant_tenant"
@@ -227,7 +227,7 @@ declare -A test_scenario21=(
     [jmx]="oauth/OAuth_Jwt_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK JWT_GRANT_FLOW"
+    [modes]="FULL JWT_GRANT_FLOW"
 )
 declare -A test_scenario22=(
     [name]="22-oauth_jwt_grant_tenant"

--- a/two-node-cluster/run-performance-tests.sh
+++ b/two-node-cluster/run-performance-tests.sh
@@ -38,7 +38,7 @@ declare -A test_scenario0=(
     [jmx]="authenticate/Authenticate_Super_Tenant_User.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL"
 )
 declare -A test_scenario1=(
     [name]="01-oauth_auth_code_redirect_with_consent"
@@ -74,7 +74,7 @@ declare -A test_scenario4=(
     [jmx]="oauth/OAuth_Client_Credentials_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL"
+    [modes]="FULL QUICK"
 )
 declare -A test_scenario5=(
     [name]="05-oidc_auth_code_redirect_with_consent"
@@ -203,22 +203,22 @@ declare -A test_scenario18=(
     [modes]="FULL"
 )
 declare -A test_scenario19=(
-  [name]="19-oidc_device_code_grant"
-  [display_name]="Device Code Grant Flow"
-  [description]="Obtain an access token using the OAuth 2.0 device code grant type."
-  [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
-  [tenantMode]=false
-  [skip]=false
-  [modes]="FULL DEVICE_FLOW"
+    [name]="19-oidc_device_code_grant"
+    [display_name]="Device Code Grant Flow"
+    [description]="Obtain an access token using the OAuth 2.0 device code grant type."
+    [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
+    [tenantMode]=false
+    [skip]=false
+    [modes]="FULL DEVICE_FLOW"
 )
 declare -A test_scenario20=(
-  [name]="20-oidc_device_code_grant_tenant"
-  [display_name]="Device Code Grant Flow"
-  [description]="Obtain an access token using the OAuth 2.0 device code grant type."
-  [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
-  [tenantMode]=true
-  [skip]=true
-  [modes]="FULL DEVICE_FLOW"
+    [name]="20-oidc_device_code_grant_tenant"
+    [display_name]="Device Code Grant Flow"
+    [description]="Obtain an access token using the OAuth 2.0 device code grant type."
+    [jmx]="oauth/OAuth_DeviceCode_Grant.jmx"
+    [tenantMode]=false
+    [skip]=true
+    [modes]="FULL DEVICE_FLOW"
 )
 declare -A test_scenario21=(
     [name]="21-oauth_jwt_grant_tenant"
@@ -227,7 +227,7 @@ declare -A test_scenario21=(
     [jmx]="oauth/OAuth_Jwt_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL JWT_GRANT_FLOW"
+    [modes]="FULL QUICK JWT_GRANT_FLOW"
 )
 declare -A test_scenario22=(
     [name]="22-oauth_jwt_grant_tenant"

--- a/two-node-cluster/run-performance-tests.sh
+++ b/two-node-cluster/run-performance-tests.sh
@@ -74,7 +74,7 @@ declare -A test_scenario4=(
     [jmx]="oauth/OAuth_Client_Credentials_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL"
+    [modes]="FULL PUBLISH"
 )
 declare -A test_scenario5=(
     [name]="05-oidc_auth_code_redirect_with_consent"
@@ -83,7 +83,7 @@ declare -A test_scenario5=(
     [jmx]="oidc/OIDC_AuthCode_Redirect_WithConsent.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL QUICK PUBLISH"
 )
 declare -A test_scenario6=(
     [name]="06-oidc_implicit_redirect_with_consent"
@@ -101,7 +101,7 @@ declare -A test_scenario7=(
     [jmx]="oidc/OIDC_Password_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL QUICK PUBLISH"
 )
 declare -A test_scenario8=(
     [name]="08-oidc_request_path_authenticator"
@@ -119,7 +119,7 @@ declare -A test_scenario9=(
     [jmx]="saml/SAML2_SSO_Redirect_Binding.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL QUICK"
+    [modes]="FULL QUICK PUBLISH"
 )
 declare -A test_scenario10=(
     [name]="10-oauth_auth_code_redirect_with_consent_tenant"
@@ -227,7 +227,7 @@ declare -A test_scenario21=(
     [jmx]="oauth/OAuth_Jwt_Grant.jmx"
     [tenantMode]=false
     [skip]=false
-    [modes]="FULL JWT_GRANT_FLOW"
+    [modes]="FULL JWT_GRANT_FLOW PUBLISH"
 )
 declare -A test_scenario22=(
     [name]="22-oauth_jwt_grant_tenant"


### PR DESCRIPTION
## Purpose
> In real-world scenarios, there is usually a delay in the login page when the end user enters login credentials. By incorporating this delay, we can expect the response time to be more reflective of actual scenarios.

Eg: SAML2 SSO Redirect Binding

<img width="468" alt="image" src="https://github.com/wso2/performance-is/assets/59449070/e2092510-d570-4129-8769-f6c8d42fd7dd">

**Added delay for the following scenarios**

- SAML2 SSO Redirect Binding
- OIDC Auth Code Grant Redirect With Consent

> Apart from that following scenarios were selected as benchmarks for publishing performance results.

- SAML2 SSO Redirect Binding
- OIDC Auth Code Grant Redirect With Consent
- Client Credentials Grant Type
- OIDC Password Grant Type
- JWT Bearer Grant Flow

Therefore they were added to a separate mode called `PUBLISH`.

<img width="805" alt="Screenshot 2023-06-02 at 14 52 52" src="https://github.com/wso2/performance-is/assets/59449070/4942f268-ee73-4c40-aac4-64c91305420d">

## Goals
> A delay of 4 - 8 seconds for user input was added to the authentication process

## Approach
**Note:**
Delay times are estimated based on the following factors:
- Selecting a single password from a password manager takes an average of 2 seconds.
- Selecting a password from a password manager with multiple passwords takes an average of 3 - 4 seconds.
- Manually providing input takes an average of 5 - 8 seconds.

Based on the above factors 4 - 8 seconds random delay was integrated

## Related Issues
> * https://github.com/wso2/product-is/issues/15460

## Test environment
> [wso2is-6.1.0-rc1](https://github.com/wso2/product-is/releases/download/v6.1.0-rc1/wso2is-6.1.0-rc1.zip)



Test Parameter | Description | Values
-- | -- | --
SAML2 SSO Redirect Binding | Obtain a SAML 2 assertion response using redirect binding. | Refer to the above table.
Heap Size | The amount of memory allocated to the application | 2G
Concurrent Users | The number of users accessing the application at the same time. | 50, 100, 150, 300, 500
IS Instance Type | The AWS instance type used to run the Identity Server. | c5.xlarge
IS DB Instance Type | The AWS RDS instance type used. | db.m4.2xlarge
JDK version | The JDK version used to run the Identity Server. | JDK 11.0.15.1
 
## Related Mails
Mail: Presenting our performance results in an optimal way to do capacity planning for our customers