### PR TITLE
Remove outboundProvisioningIdps from SP creation

### DIFF
--- a/common/jmeter/setup/TestData_Add_OAuth_Apps_Requesting_Claims.jmx
+++ b/common/jmeter/setup/TestData_Add_OAuth_Apps_Requesting_Claims.jmx
@@ -491,8 +491,7 @@ if (y == 0) {
   &quot;provisioningConfigurations&quot;: {&#xd;
     &quot;inboundProvisioning&quot;: {&#xd;
       &quot;provisioningUserstoreDomain&quot;: &quot;PRIMARY&quot;&#xd;
-    },&#xd;
-    &quot;outboundProvisioningIdps&quot;: []&#xd;
+    }&#xd;
   }&#xd;
 }&#xd;
 </stringProp>

--- a/common/jmeter/setup/TestData_Add_OAuth_Apps_Without_Consent.jmx
+++ b/common/jmeter/setup/TestData_Add_OAuth_Apps_Without_Consent.jmx
@@ -494,8 +494,7 @@ if (y == 0) {
   &quot;provisioningConfigurations&quot;: {&#xd;
     &quot;inboundProvisioning&quot;: {&#xd;
       &quot;provisioningUserstoreDomain&quot;: &quot;PRIMARY&quot;&#xd;
-    },&#xd;
-    &quot;outboundProvisioningIdps&quot;: []&#xd;
+    }&#xd;
   }&#xd;
 }&#xd;
 </stringProp>

--- a/common/jmeter/setup/TestData_Add_Tenant_Device_Flow_OAuth_Apps.jmx
+++ b/common/jmeter/setup/TestData_Add_Tenant_Device_Flow_OAuth_Apps.jmx
@@ -296,8 +296,7 @@ if (y == 0) {
   &quot;provisioningConfigurations&quot;: {&#xd;
     &quot;inboundProvisioning&quot;: {&#xd;
       &quot;provisioningUserstoreDomain&quot;: &quot;PRIMARY&quot;&#xd;
-    },&#xd;
-    &quot;outboundProvisioningIdps&quot;: []&#xd;
+    }&#xd;
   }&#xd;
 }</stringProp>
                   <stringProp name="Argument.metadata">=</stringProp>

--- a/common/jmeter/setup/TestData_Add_Tenant_OAuth_Apps.jmx
+++ b/common/jmeter/setup/TestData_Add_Tenant_OAuth_Apps.jmx
@@ -301,8 +301,7 @@ if (y == 0) {
   &quot;provisioningConfigurations&quot;: {&#xd;
     &quot;inboundProvisioning&quot;: {&#xd;
       &quot;provisioningUserstoreDomain&quot;: &quot;PRIMARY&quot;&#xd;
-    },&#xd;
-    &quot;outboundProvisioningIdps&quot;: []&#xd;
+    }&#xd;
   }&#xd;
 }</stringProp>
                   <stringProp name="Argument.metadata">=</stringProp>


### PR DESCRIPTION
## Purpose
> As we no longer support `Application-based outbound provisioning support` removing the config from app creation logic.