### PR TITLE
Token exchange fixes

### DIFF
--- a/common/jmeter/setup/TestData_Get_OAuth_Jwt_Token.jmx
+++ b/common/jmeter/setup/TestData_Get_OAuth_Jwt_Token.jmx
@@ -217,7 +217,7 @@ if (y == 0) {
             <collectionProp name="Arguments.arguments">
               <elementProp name="grant_type" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">Password_1</stringProp>
+                <stringProp name="Argument.value">password</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">grant_type</stringProp>


### PR DESCRIPTION
## Purpose
> - Add grant type as `urn:ietf:params:oauth:grant-type:token-exchange`.
> - Add missing subject_token parameter.