### PR TITLE
Add JMeter Script for OIDC Password Grant Validation with Hybrid Flow

### DIFF
--- a/common/jmeter/oidc/OIDC_Password_Grant_Common_Auth.jmx
+++ b/common/jmeter/oidc/OIDC_Password_Grant_Common_Auth.jmx
@@ -1,0 +1,445 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC - Password Grant Type Common Auth">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Server Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="is_host" elementType="Argument">
+            <stringProp name="Argument.name">is_host</stringProp>
+            <stringProp name="Argument.value">${__P(host,localhost)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="is_port" elementType="Argument">
+            <stringProp name="Argument.name">is_port</stringProp>
+            <stringProp name="Argument.value">${__P(port,9443)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Test Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="usernamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">usernamePrefix</stringProp>
+            <stringProp name="Argument.value">isTestUser</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="password" elementType="Argument">
+            <stringProp name="Argument.name">password</stringProp>
+            <stringProp name="Argument.value">Password_1</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="scope" elementType="Argument">
+            <stringProp name="Argument.name">scope</stringProp>
+            <stringProp name="Argument.value">openid</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="consumerKeyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">consumerKeyPrefix</stringProp>
+            <stringProp name="Argument.value">consumerKey</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tenantDomainPrefix" elementType="Argument">
+            <stringProp name="Argument.name">tenantDomainPrefix</stringProp>
+            <stringProp name="Argument.value">dummytenant_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="callbackUriPrefix" elementType="Argument">
+            <stringProp name="Argument.name">callbackUriPrefix</stringProp>
+            <stringProp name="Argument.value">https://localhost/callback</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="chkRemember" elementType="Argument">
+            <stringProp name="Argument.name">chkRemember</stringProp>
+            <stringProp name="Argument.value">off</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="noOfThreads" elementType="Argument">
+            <stringProp name="Argument.name">noOfThreads</stringProp>
+            <stringProp name="Argument.value">${__P(concurrency,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfUsers" elementType="Argument">
+            <stringProp name="Argument.name">noOfUsers</stringProp>
+            <stringProp name="Argument.value">${__P(userCount,100)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="timeToRun" elementType="Argument">
+            <stringProp name="Argument.name">timeToRun</stringProp>
+            <stringProp name="Argument.value">${__P(time,100)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="rampUpPeriod" elementType="Argument">
+            <stringProp name="Argument.name">rampUpPeriod</stringProp>
+            <stringProp name="Argument.value">${__P(rampUpPeriod,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfSPs" elementType="Argument">
+            <stringProp name="Argument.name">noOfSPs</stringProp>
+            <stringProp name="Argument.value">${__P(spCount,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="constantTPS" elementType="Argument">
+            <stringProp name="Argument.name">constantTPS</stringProp>
+            <stringProp name="Argument.value">${__P(constantTPS,10000)}</stringProp>
+            <stringProp name="Argument.desc">samples per minute.</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tenantMode" elementType="Argument">
+            <stringProp name="Argument.name">tenantMode</stringProp>
+            <stringProp name="Argument.value">${__P(tenantMode,false)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfTenants" elementType="Argument">
+            <stringProp name="Argument.name">noOfTenants</stringProp>
+            <stringProp name="Argument.value">${__P(noOfTenants,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfNodes" elementType="Argument">
+            <stringProp name="Argument.name">noOfNodes</stringProp>
+            <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="deployment" elementType="Argument">
+            <stringProp name="Argument.name">deployment</stringProp>
+            <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Password Grant">
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+        <stringProp name="ThreadGroup.num_threads">${noOfThreads}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${rampUpPeriod}</stringProp>
+        <stringProp name="ThreadGroup.duration">${timeToRun}</stringProp>
+        <longProp name="ThreadGroup.delay">0</longProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <intProp name="LoopController.loops">-1</intProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Tenant Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfTenants}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">tenantIdx</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random SP Count">
+          <stringProp name="maximumValue">${noOfSPs}</stringProp>
+          <stringProp name="minimumValue">1</stringProp>
+          <stringProp name="outputFormat"></stringProp>
+          <boolProp name="perThread">true</boolProp>
+          <stringProp name="randomSeed"></stringProp>
+          <stringProp name="variableName">spCountIdRandom</stringProp>
+        </RandomVariableConfig>
+        <hashTree/>
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random User Counter">
+          <stringProp name="maximumValue">${noOfUsers}</stringProp>
+          <stringProp name="minimumValue">1</stringProp>
+          <stringProp name="outputFormat"></stringProp>
+          <boolProp name="perThread">true</boolProp>
+          <stringProp name="randomSeed"></stringProp>
+          <stringProp name="variableName">userCountId</stringProp>
+        </RandomVariableConfig>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="script">String username = &quot;&quot;;
+String clientSecret = &quot;&quot;;
+String clientId = &quot;&quot;;
+String redirectUri = &quot;&quot;;
+String tokenEndpoint = &quot;&quot;;
+
+if (new String(&quot;${tenantMode}&quot;).equals(&quot;true&quot;)) {
+
+username = &quot;${usernamePrefix}${userCountId}@${tenantDomainPrefix}${tenantIdx}.com&quot;;
+clientSecret = &quot;${consumerSecretPrefix}${spCountIdRandom}${tenantDomainPrefix}${tenantIdx}&quot;;
+clientId = &quot;${consumerKeyPrefix}${spCountIdRandom}${tenantDomainPrefix}${tenantIdx}&quot;;
+redirectUri = &quot;${callbackUriPrefix}${spCountIdRandom}${tenantDomainPrefix}${tenantIdx}&quot;;
+tokenEndpoint = &quot;/t/${tenantDomainPrefix}${tenantIdx}.com/oauth2/token&quot;;
+
+} else {
+
+username = &quot;${usernamePrefix}${userCountId}&quot;;
+clientSecret = &quot;${consumerSecretPrefix}${spCountIdRandom}&quot;;
+clientId = &quot;${consumerKeyPrefix}${spCountIdRandom}&quot;;
+redirectUri = &quot;${callbackUriPrefix}${spCountIdRandom}&quot;;
+tokenEndpoint = &quot;/oauth2/token&quot;;
+
+}
+
+vars.put(&quot;username&quot;, new String(username));
+vars.put(&quot;clientSecret&quot;, new String(clientSecret));
+vars.put(&quot;clientId&quot;, new String(clientId));
+vars.put(&quot;redirectUri&quot;,new String(redirectUri));
+vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()">
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
+int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
+int x = Integer.parseInt(vars.get(&quot;spCountId&quot;));
+int y = x - (x/numOfNodes)*numOfNodes;
+
+if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
+    vars.put(&quot;serverNode&quot;, &quot;node1&quot;);
+} else if (y == 1) {
+    vars.put(&quot;serverNode&quot;, &quot;node2&quot;);
+} else if (y == 2) {
+    vars.put(&quot;serverNode&quot;, &quot;node3&quot;);
+} else {
+    vars.put(&quot;serverNode&quot;, &quot;node4&quot;);
+}</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">X-Server-Select</stringProp>
+              <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Accept</stringProp>
+              <stringProp name="Header.value">application/json</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get Common Auth Id">
+          <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/oauth2/authorize/</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="username" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${username}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">username</stringProp>
+              </elementProp>
+              <elementProp name="password" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${password}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">password</stringProp>
+              </elementProp>
+              <elementProp name="scope" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${scope}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">scope</stringProp>
+              </elementProp>
+              <elementProp name="client_id" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${clientId}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">client_id</stringProp>
+              </elementProp>
+              <elementProp name="response_type" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">code+id_token</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">response_type</stringProp>
+              </elementProp>
+              <elementProp name="redirect_uri" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${redirectUri}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">redirect_uri</stringProp>
+              </elementProp>
+              <elementProp name="state" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">logpg</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">state</stringProp>
+              </elementProp>
+              <elementProp name="nonce" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">test</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">nonce</stringProp>
+              </elementProp>
+              <elementProp name="chkRemember" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${chkRemember}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">chkRemember</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103172738">HTTP/1.1 302</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get commonAuthId</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - commonAuthId">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-395913554">commonAuthId</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">true</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get commonAuthId</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regular Expression Extractor">
+            <stringProp name="RegexExtractor.useHeaders">true</stringProp>
+            <stringProp name="RegexExtractor.refname">commonAuthId</stringProp>
+            <stringProp name="RegexExtractor.regex">Set-Cookie: commonAuthId=(.*?);</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">Not Found</stringProp>
+            <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
+            <stringProp name="RegexExtractor.match_number">1</stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get Token Password Grant">
+          <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/oauth2/authorize/</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="scope" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${scope}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">scope</stringProp>
+              </elementProp>
+              <elementProp name="client_id" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${clientId}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">client_id</stringProp>
+              </elementProp>
+              <elementProp name="response_type" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">code+id_token</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">response_type</stringProp>
+              </elementProp>
+              <elementProp name="redirect_uri" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${redirectUri}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">redirect_uri</stringProp>
+              </elementProp>
+              <elementProp name="state" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">logpg</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">state</stringProp>
+              </elementProp>
+              <elementProp name="nonce" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">test</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">nonce</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">X-Server-Select</stringProp>
+                <stringProp name="Header.value">${serverNode}</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Accept</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Cookie</stringProp>
+                <stringProp name="Header.value">commonAuthId=${commonAuthId}</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103172738">HTTP/1.1 302</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get commonAuthId</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - id token">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-302143019">id_token</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">true</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+        </hashTree>
+        <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput">
+          <intProp name="calcMode">1</intProp>
+          <stringProp name="throughput">${constantTPS}</stringProp>
+        </ConstantThroughputTimer>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/common/jmeter/oidc/OIDC_Password_Grant_RBAC.jmx
+++ b/common/jmeter/oidc/OIDC_Password_Grant_RBAC.jmx
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
   <hashTree>
-    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC - Password Grant Type for RBAC">
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC - Password Grant Type For RBAC">
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
-      <boolProp name="TestPlan.functional_mode">false</boolProp>
-      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
     </TestPlan>
     <hashTree>
       <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Server Variables">
@@ -34,32 +32,32 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="usernamePrefix" elementType="Argument">
             <stringProp name="Argument.name">usernamePrefix</stringProp>
-            <stringProp name="Argument.value">testUser</stringProp>
+            <stringProp name="Argument.value">isTestUser</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
-          <elementProp name="passwordPrefix" elementType="Argument">
-            <stringProp name="Argument.name">passwordPrefix</stringProp>
-            <stringProp name="Argument.value">testPassword@</stringProp>
+          <elementProp name="password" elementType="Argument">
+            <stringProp name="Argument.name">password</stringProp>
+            <stringProp name="Argument.value">Password_1</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="scope" elementType="Argument">
             <stringProp name="Argument.name">scope</stringProp>
-            <stringProp name="Argument.value">openid+internal_application_mgt_view</stringProp>
+            <stringProp name="Argument.value">testScope</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="consumerKeyPrefix" elementType="Argument">
             <stringProp name="Argument.name">consumerKeyPrefix</stringProp>
-            <stringProp name="Argument.value">rbacConsumerKey</stringProp>
+            <stringProp name="Argument.value">consumerKey</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="consumerSecretPrefix" elementType="Argument">
             <stringProp name="Argument.name">consumerSecretPrefix</stringProp>
-            <stringProp name="Argument.value">rbacConsumerSecret</stringProp>
+            <stringProp name="Argument.value">consumerSecret</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="tenantDomainPrefix" elementType="Argument">
             <stringProp name="Argument.name">tenantDomainPrefix</stringProp>
-            <stringProp name="Argument.value">dummyTenant</stringProp>
+            <stringProp name="Argument.value">dummytenant</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -69,17 +67,17 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="noOfThreads" elementType="Argument">
             <stringProp name="Argument.name">noOfThreads</stringProp>
-            <stringProp name="Argument.value">${__P(concurrency,3)}</stringProp>
+            <stringProp name="Argument.value">${__P(concurrency,1)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
-          <elementProp name="noOfUsers" elementType="Argument">
-            <stringProp name="Argument.name">noOfUsers</stringProp>
-            <stringProp name="Argument.value">${__P(userCount,1000)}</stringProp>
+          <elementProp name="noOfUsersPerSP" elementType="Argument">
+            <stringProp name="Argument.name">noOfUsersPerSP</stringProp>
+            <stringProp name="Argument.value">${__P(userCount,10)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="timeToRun" elementType="Argument">
             <stringProp name="Argument.name">timeToRun</stringProp>
-            <stringProp name="Argument.value">${__P(time,10)}</stringProp>
+            <stringProp name="Argument.value">${__P(time,100)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="rampUpPeriod" elementType="Argument">
@@ -89,12 +87,12 @@
           </elementProp>
           <elementProp name="noOfSPs" elementType="Argument">
             <stringProp name="Argument.name">noOfSPs</stringProp>
-            <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
+            <stringProp name="Argument.value">${__P(spCount,10)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="constantTPS" elementType="Argument">
             <stringProp name="Argument.name">constantTPS</stringProp>
-            <stringProp name="Argument.value">${__P(constantTPS,10000000)}</stringProp>
+            <stringProp name="Argument.value">${__P(constantTPS,10000)}</stringProp>
             <stringProp name="Argument.desc">samples per minute.</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
@@ -105,7 +103,7 @@
           </elementProp>
           <elementProp name="noOfTenants" elementType="Argument">
             <stringProp name="Argument.name">noOfTenants</stringProp>
-            <stringProp name="Argument.value">${__P(noOfTenants,100)}</stringProp>
+            <stringProp name="Argument.value">${__P(noOfTenants,1)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="noOfNodes" elementType="Argument">
@@ -136,89 +134,61 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
-        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Tenant Counter">
-          <stringProp name="CounterConfig.start">1</stringProp>
-          <stringProp name="CounterConfig.end">${noOfTenants}</stringProp>
-          <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">tenant_idx</stringProp>
-          <stringProp name="CounterConfig.format"></stringProp>
-          <boolProp name="CounterConfig.per_user">false</boolProp>
-        </CounterConfig>
-        <hashTree/>
-        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="SP Counter">
-          <stringProp name="CounterConfig.start">1</stringProp>
-          <stringProp name="CounterConfig.end">${noOfSPs}</stringProp>
-          <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">sp_count_id</stringProp>
-          <stringProp name="CounterConfig.format"></stringProp>
-          <boolProp name="CounterConfig.per_user">false</boolProp>
-        </CounterConfig>
-        <hashTree/>
-        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="User Counter">
-          <stringProp name="CounterConfig.start">1</stringProp>
-          <stringProp name="CounterConfig.end">${noOfUsers}</stringProp>
-          <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">user_count_id</stringProp>
-          <stringProp name="CounterConfig.format"></stringProp>
-          <boolProp name="CounterConfig.per_user">false</boolProp>
-        </CounterConfig>
-        <hashTree/>
-        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random_sp_count">
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random SP Counter">
           <stringProp name="maximumValue">${noOfSPs}</stringProp>
           <stringProp name="minimumValue">1</stringProp>
           <stringProp name="outputFormat"></stringProp>
           <boolProp name="perThread">true</boolProp>
           <stringProp name="randomSeed"></stringProp>
-          <stringProp name="variableName">sp_count_id_random</stringProp>
+          <stringProp name="variableName">spCountIdRandom</stringProp>
         </RandomVariableConfig>
         <hashTree/>
         <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
           <boolProp name="resetInterpreter">false</boolProp>
           <stringProp name="parameters"></stringProp>
           <stringProp name="filename"></stringProp>
-          <stringProp name="script">String tenantMode = vars.get(&quot;tenantMode&quot;);
-String consumerKeyPrefix = vars.get(&quot;consumerKeyPrefix&quot;);
-String consumerSecretPrefix = vars.get(&quot;consumerSecretPrefix&quot;);
-String tenantDomainPrefix = vars.get(&quot;tenantDomainPrefix&quot;);
-String tenantIndex = vars.get(&quot;tenant_idx&quot;);
-String sp_count_id_random = vars.get(&quot;sp_count_id_random&quot;);
-String passwordPrefix = vars.get(&quot;passwordPrefix&quot;);
+          <stringProp name="script">import java.util.Random;
 
-String username = &quot;&quot;;
-String client_secret = &quot;&quot;;
-String client_id = &quot;&quot;;
-String redirect_uri = &quot;&quot;;
-String tokenEndpoint = &quot;&quot;;
-String password = &quot;&quot;;
+try {
+    int spCountId = Integer.parseInt(vars.get(&quot;spCountIdRandom&quot;));
+    int userCount = Integer.parseInt(vars.get(&quot;noOfUsersPerSP&quot;));
+    int noOfSP = Integer.parseInt(vars.get(&quot;noOfSPs&quot;));
+    
+    int minUserCount;
+    int maxUserCount;
 
+    if (spCountId == 1) {
+        minUserCount = 1;
+    } else if (spCountId == 0){
+	   log.info(&quot;No application selected&quot;);
+	   minUserCount = 1;
+    } else {
+        minUserCount = (userCount * (spCountId - 1)) + 1;
+    }
+    maxUserCount = userCount * spCountId;
 
-if (new String(tenantMode).equals(&quot;true&quot;)) {
+    Random rand = new Random();
+    int randomUserCount = rand.nextInt((maxUserCount - minUserCount) + 1) + minUserCount;
+    vars.put(&quot;userCountId&quot;, Integer.toString(randomUserCount));
 
-username = &quot;${usernamePrefix}${user_count_id}@${tenantDomainPrefix}${tenant_idx}.com&quot;;
-client_secret = &quot;${consumerSecretPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
-client_id = &quot;${consumerKeyPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
-redirect_uri = &quot;${callback_url_prefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
-password = &quot;${passwordPrefix}${user_count_id}${tenantDomainPrefix}${tenant_idx}&quot;;
-tokenEndpoint = &quot;/t/${tenantDomainPrefix}${tenant_idx}.com/oauth2/token&quot;;
-
-} else {
-
-username = &quot;${usernamePrefix}${user_count_id}&quot;;
-client_secret = &quot;${consumerSecretPrefix}${sp_count_id}&quot;;
-client_id = &quot;${consumerKeyPrefix}${sp_count_id}&quot;;
-redirect_uri = &quot;${callback_url_prefix}${sp_count_id}&quot;;
-password = &quot;${passwordPrefix}${user_count_id}&quot;;
-tokenEndpoint = &quot;/oauth2/token&quot;;
-
+} catch (NumberFormatException ex) {
+    log.error(&quot;Error parsing integers from JMeter variables: &quot; + ex.toString());
+    throw ex;
+} catch (Exception ex) {
+    log.error(&quot;An unexpected error occurred: &quot; + ex.toString());
+    throw ex;
 }
-
-vars.put(&quot;username&quot;, new String(username));
-vars.put(&quot;client_secret&quot;, new String(client_secret));
-vars.put(&quot;client_id&quot;, new String(client_id));
-vars.put(&quot;redirect_uri&quot;,new String(redirect_uri));
-vars.put(&quot;password&quot;, new String(password));
-vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
+</stringProp>
         </BeanShellPreProcessor>
+        <hashTree/>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Tenant Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfTenants}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">tenantIdx</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
         <hashTree/>
         <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()">
           <stringProp name="filename"></stringProp>
@@ -226,7 +196,7 @@ vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
           <boolProp name="resetInterpreter">false</boolProp>
           <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
 int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
-int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int x = Integer.parseInt(vars.get(&quot;spCountIdRandom&quot;));
 int y = x - (x/numOfNodes)*numOfNodes;
 
 if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
@@ -254,7 +224,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
           <stringProp name="HTTPSampler.port">${is_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
-          <stringProp name="HTTPSampler.path">${tokenEndpoint}</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/${tokenEndpoint}</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
@@ -291,14 +261,14 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
               </elementProp>
               <elementProp name="client_secret" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">${client_secret}</stringProp>
+                <stringProp name="Argument.value">${clientSecret}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">client_secret</stringProp>
               </elementProp>
               <elementProp name="client_id" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">${client_id}</stringProp>
+                <stringProp name="Argument.value">${clientId}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">client_id</stringProp>
@@ -308,7 +278,49 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">String tenantMode = vars.get(&quot;tenantMode&quot;);
+String consumerKeyPrefix = vars.get(&quot;consumerKeyPrefix&quot;);
+String consumerSecretPrefix = vars.get(&quot;consumerSecretPrefix&quot;);
+String tenantDomainPrefix = vars.get(&quot;tenantDomainPrefix&quot;);
+String tenantIndex = vars.get(&quot;tenantIdx&quot;);
+String userCountId = vars.get(&quot;userCountId&quot;);
+
+String username = &quot;&quot;;
+String client_secret = &quot;&quot;;
+String client_id = &quot;&quot;;
+String redirect_uri = &quot;&quot;;
+String tokenEndpoint = &quot;&quot;;
+
+if (new String(tenantMode).equals(&quot;true&quot;)) {
+
+username = &quot;${usernamePrefix}&quot;+userCountId+&quot;@${tenantDomainPrefix}${tenantIdx}.com&quot;;
+client_secret = &quot;${consumerSecretPrefix}${spCountIdRandom}${tenantDomainPrefix}${tenantIdx}&quot;;
+client_id = &quot;${consumerKeyPrefix}${spCountIdRandom}${tenantDomainPrefix}${tenantIdx}&quot;;
+redirect_uri = &quot;${callback_url_prefix}${spCountIdRandom}${tenantDomainPrefix}${tenantIdx}&quot;;
+tokenEndpoint = &quot;/t/${tenantDomainPrefix}${tenantIdx}.com/oauth2/token&quot;;
+
+} else {
+
+username = &quot;${usernamePrefix}&quot;+userCountId;
+client_secret = &quot;${consumerSecretPrefix}${spCountIdRandom}&quot;;
+client_id = &quot;${consumerKeyPrefix}${spCountIdRandom}&quot;;
+redirect_uri = &quot;${callback_url_prefix}${spCountIdRandom}&quot;;
+tokenEndpoint = &quot;/oauth2/token&quot;;
+
+}
+
+vars.put(&quot;username&quot;, new String(username));
+vars.put(&quot;clientSecret&quot;, new String(client_secret));
+vars.put(&quot;clientId&quot;, new String(client_id));
+vars.put(&quot;redirectUri&quot;,new String(redirect_uri));
+vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>
             </collectionProp>
@@ -318,7 +330,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - access token" enabled="true">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - access token">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="417462488">&quot;access_token&quot;:</stringProp>
             </collectionProp>
@@ -328,13 +340,14 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - id token" enabled="true">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - id token">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="731531919">&quot;id_token&quot;:</stringProp>
+              <stringProp name="-802335680">${scope}</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">true</boolProp>
-            <intProp name="Assertion.test_type">2</intProp>
+            <intProp name="Assertion.test_type">34</intProp>
             <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
           </ResponseAssertion>
           <hashTree/>
@@ -345,262 +358,6 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </ConstantThroughputTimer>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Password Grant" enabled="false">
-        <stringProp name="ThreadGroup.num_threads">${noOfBurst}</stringProp>
-        <intProp name="ThreadGroup.ramp_time">0</intProp>
-        <longProp name="ThreadGroup.duration">180</longProp>
-        <longProp name="ThreadGroup.delay">360</longProp>
-        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
-        <boolProp name="ThreadGroup.scheduler">true</boolProp>
-        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
-        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
-          <stringProp name="LoopController.loops">1</stringProp>
-          <boolProp name="LoopController.continue_forever">false</boolProp>
-        </elementProp>
-      </ThreadGroup>
-      <hashTree>
-        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Tenant Counter">
-          <stringProp name="CounterConfig.start">1</stringProp>
-          <stringProp name="CounterConfig.end">${noOfTenants}</stringProp>
-          <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">tenant_idx</stringProp>
-          <stringProp name="CounterConfig.format"></stringProp>
-          <boolProp name="CounterConfig.per_user">false</boolProp>
-        </CounterConfig>
-        <hashTree/>
-        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="SP Counter" enabled="true">
-          <stringProp name="CounterConfig.start">1</stringProp>
-          <stringProp name="CounterConfig.end">${noOfSPs}</stringProp>
-          <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">sp_count_id</stringProp>
-          <stringProp name="CounterConfig.format"></stringProp>
-          <boolProp name="CounterConfig.per_user">false</boolProp>
-        </CounterConfig>
-        <hashTree/>
-        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random_sp_count" enabled="true">
-          <stringProp name="maximumValue">${noOfSPs}</stringProp>
-          <stringProp name="minimumValue">1</stringProp>
-          <stringProp name="outputFormat"></stringProp>
-          <boolProp name="perThread">true</boolProp>
-          <stringProp name="randomSeed"></stringProp>
-          <stringProp name="variableName">sp_count_id_random</stringProp>
-        </RandomVariableConfig>
-        <hashTree/>
-        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random User Counter" enabled="true">
-          <stringProp name="maximumValue">${noOfUsers}</stringProp>
-          <stringProp name="minimumValue">1</stringProp>
-          <stringProp name="outputFormat"></stringProp>
-          <boolProp name="perThread">true</boolProp>
-          <stringProp name="randomSeed"></stringProp>
-          <stringProp name="variableName">user_count_id</stringProp>
-        </RandomVariableConfig>
-        <hashTree/>
-        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
-          <boolProp name="resetInterpreter">false</boolProp>
-          <stringProp name="parameters"></stringProp>
-          <stringProp name="filename"></stringProp>
-          <stringProp name="script">String tenantMode = vars.get(&quot;tenantMode&quot;);
-String consumerKeyPrefix = vars.get(&quot;consumerKeyPrefix&quot;);
-String consumerSecretPrefix = vars.get(&quot;consumerSecretPrefix&quot;);
-String tenantDomainPrefix = vars.get(&quot;tenantDomainPrefix&quot;);
-String tenantIndex = vars.get(&quot;tenant_idx&quot;);
-String sp_count_id_random = vars.get(&quot;sp_count_id_random&quot;);
-
-String username = &quot;&quot;;
-String client_secret = &quot;&quot;;
-String client_id = &quot;&quot;;
-String redirect_uri = &quot;&quot;;
-String tokenEndpoint = &quot;&quot;;
-
-
-if (new String(tenantMode).equals(&quot;true&quot;)) {
-
-username = &quot;${usernamePrefix}${user_count_id}@${tenantDomainPrefix}${tenant_idx}.com&quot;;
-client_secret = &quot;${consumerSecretPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
-client_id = &quot;${consumerKeyPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
-redirect_uri = &quot;${callback_url_prefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
-tokenEndpoint = &quot;/t/${tenantDomainPrefix}${tenant_idx}.com/oauth2/token&quot;;
-
-} else {
-
-username = &quot;${usernamePrefix}${user_count_id}&quot;;
-client_secret = &quot;${consumerSecretPrefix}${sp_count_id}&quot;;
-client_id = &quot;${consumerKeyPrefix}${sp_count_id}&quot;;
-redirect_uri = &quot;${callback_url_prefix}${sp_count_id}&quot;;
-tokenEndpoint = &quot;/oauth2/token&quot;;
-
-}
-
-vars.put(&quot;username&quot;, new String(username));
-vars.put(&quot;client_secret&quot;, new String(client_secret));
-vars.put(&quot;client_id&quot;, new String(client_id));
-vars.put(&quot;redirect_uri&quot;,new String(redirect_uri));
-vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
-        </BeanShellPreProcessor>
-        <hashTree/>
-        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()" enabled="true">
-          <stringProp name="filename"></stringProp>
-          <stringProp name="parameters"></stringProp>
-          <boolProp name="resetInterpreter">false</boolProp>
-          <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
-int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
-int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
-int y = x - (x/numOfNodes)*numOfNodes;
-
-if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
-    vars.put(&quot;serverNode&quot;, &quot;node1&quot;);
-} else if (y == 1) {
-    vars.put(&quot;serverNode&quot;, &quot;node2&quot;);
-} else if (y == 2) {
-    vars.put(&quot;serverNode&quot;, &quot;node3&quot;);
-} else {
-    vars.put(&quot;serverNode&quot;, &quot;node4&quot;);
-}</stringProp>
-        </BeanShellPreProcessor>
-        <hashTree/>
-        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
-          <collectionProp name="HeaderManager.headers">
-            <elementProp name="" elementType="Header">
-              <stringProp name="Header.name">X-Server-Select</stringProp>
-              <stringProp name="Header.value">${serverNode}</stringProp>
-            </elementProp>
-          </collectionProp>
-        </HeaderManager>
-        <hashTree/>
-        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
-          <stringProp name="IfController.condition">${__jexl3(&quot;${noOfBurst}&quot; != &quot;0&quot;)}</stringProp>
-          <boolProp name="IfController.evaluateAll">false</boolProp>
-          <boolProp name="IfController.useExpression">true</boolProp>
-        </IfController>
-        <hashTree>
-          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 Burst GetToken_Password_Grant" enabled="true">
-            <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
-            <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
-            <stringProp name="HTTPSampler.port">${is_port}</stringProp>
-            <stringProp name="HTTPSampler.protocol">https</stringProp>
-            <stringProp name="HTTPSampler.path">${tokenEndpoint}</stringProp>
-            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-            <stringProp name="HTTPSampler.method">POST</stringProp>
-            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
-            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
-              <collectionProp name="Arguments.arguments">
-                <elementProp name="grant_type" elementType="HTTPArgument">
-                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">password</stringProp>
-                  <stringProp name="Argument.metadata">=</stringProp>
-                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">grant_type</stringProp>
-                </elementProp>
-                <elementProp name="username" elementType="HTTPArgument">
-                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${username}</stringProp>
-                  <stringProp name="Argument.metadata">=</stringProp>
-                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">username</stringProp>
-                </elementProp>
-                <elementProp name="password" elementType="HTTPArgument">
-                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${password}</stringProp>
-                  <stringProp name="Argument.metadata">=</stringProp>
-                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">password</stringProp>
-                </elementProp>
-                <elementProp name="scope" elementType="HTTPArgument">
-                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${scope}%20device_${__Random(1,10000000)}</stringProp>
-                  <stringProp name="Argument.metadata">=</stringProp>
-                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">scope</stringProp>
-                </elementProp>
-                <elementProp name="client_secret" elementType="HTTPArgument">
-                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${client_secret}</stringProp>
-                  <stringProp name="Argument.metadata">=</stringProp>
-                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">client_secret</stringProp>
-                </elementProp>
-                <elementProp name="client_id" elementType="HTTPArgument">
-                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">${client_id}</stringProp>
-                  <stringProp name="Argument.metadata">=</stringProp>
-                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
-                  <stringProp name="Argument.name">client_id</stringProp>
-                </elementProp>
-              </collectionProp>
-            </elementProp>
-            <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-          </HTTPSamplerProxy>
-          <hashTree>
-            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
-                <stringProp name="103171775">HTTP/1.1 200</stringProp>
-              </collectionProp>
-              <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
-              <boolProp name="Assertion.assume_success">false</boolProp>
-              <intProp name="Assertion.test_type">2</intProp>
-              <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
-            </ResponseAssertion>
-            <hashTree/>
-            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - access token" enabled="true">
-              <collectionProp name="Asserion.test_strings">
-                <stringProp name="417462488">&quot;access_token&quot;:</stringProp>
-              </collectionProp>
-              <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-              <boolProp name="Assertion.assume_success">true</boolProp>
-              <intProp name="Assertion.test_type">2</intProp>
-              <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
-            </ResponseAssertion>
-            <hashTree/>
-            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - id token" enabled="true">
-              <collectionProp name="Asserion.test_strings">
-                <stringProp name="731531919">&quot;id_token&quot;:</stringProp>
-              </collectionProp>
-              <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-              <boolProp name="Assertion.assume_success">true</boolProp>
-              <intProp name="Assertion.test_type">2</intProp>
-              <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
-            </ResponseAssertion>
-            <hashTree/>
-          </hashTree>
-        </hashTree>
-      </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
-        <boolProp name="ResultCollector.error_logging">false</boolProp>
-        <objProp>
-          <name>saveConfig</name>
-          <value class="SampleSaveConfiguration">
-            <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
-            <success>true</success>
-            <label>true</label>
-            <code>true</code>
-            <message>true</message>
-            <threadName>true</threadName>
-            <dataType>true</dataType>
-            <encoding>false</encoding>
-            <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
-            <samplerData>false</samplerData>
-            <xml>false</xml>
-            <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
-            <responseDataOnError>false</responseDataOnError>
-            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
-            <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
-            <sentBytes>true</sentBytes>
-            <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
-            <connectTime>true</connectTime>
-          </value>
-        </objProp>
-        <stringProp name="filename"></stringProp>
-      </ResultCollector>
-      <hashTree/>
     </hashTree>
   </hashTree>
 </jmeterTestPlan>

--- a/common/jmeter/oidc/OIDC_Password_Grant_RBAC.jmx
+++ b/common/jmeter/oidc/OIDC_Password_Grant_RBAC.jmx
@@ -1,0 +1,606 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC - Password Grant Type for RBAC">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Server Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="is_host" elementType="Argument">
+            <stringProp name="Argument.name">is_host</stringProp>
+            <stringProp name="Argument.value">${__P(host,localhost)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="is_port" elementType="Argument">
+            <stringProp name="Argument.name">is_port</stringProp>
+            <stringProp name="Argument.value">${__P(port,9443)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="adminCredentials" elementType="Argument">
+            <stringProp name="Argument.name">adminCredentials</stringProp>
+            <stringProp name="Argument.value">YWRtaW46YWRtaW4=</stringProp>
+            <stringProp name="Argument.desc">admin:admin</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Test Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="usernamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">usernamePrefix</stringProp>
+            <stringProp name="Argument.value">testUser</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="passwordPrefix" elementType="Argument">
+            <stringProp name="Argument.name">passwordPrefix</stringProp>
+            <stringProp name="Argument.value">testPassword@</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="scope" elementType="Argument">
+            <stringProp name="Argument.name">scope</stringProp>
+            <stringProp name="Argument.value">openid+internal_application_mgt_view</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="consumerKeyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">consumerKeyPrefix</stringProp>
+            <stringProp name="Argument.value">rbacConsumerKey</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="consumerSecretPrefix" elementType="Argument">
+            <stringProp name="Argument.name">consumerSecretPrefix</stringProp>
+            <stringProp name="Argument.value">rbacConsumerSecret</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tenantDomainPrefix" elementType="Argument">
+            <stringProp name="Argument.name">tenantDomainPrefix</stringProp>
+            <stringProp name="Argument.value">dummyTenant</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="noOfThreads" elementType="Argument">
+            <stringProp name="Argument.name">noOfThreads</stringProp>
+            <stringProp name="Argument.value">${__P(concurrency,3)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfUsers" elementType="Argument">
+            <stringProp name="Argument.name">noOfUsers</stringProp>
+            <stringProp name="Argument.value">${__P(userCount,1000)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="timeToRun" elementType="Argument">
+            <stringProp name="Argument.name">timeToRun</stringProp>
+            <stringProp name="Argument.value">${__P(time,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="rampUpPeriod" elementType="Argument">
+            <stringProp name="Argument.name">rampUpPeriod</stringProp>
+            <stringProp name="Argument.value">${__P(rampUpPeriod,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfSPs" elementType="Argument">
+            <stringProp name="Argument.name">noOfSPs</stringProp>
+            <stringProp name="Argument.value">${__P(spCount,1000)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="constantTPS" elementType="Argument">
+            <stringProp name="Argument.name">constantTPS</stringProp>
+            <stringProp name="Argument.value">${__P(constantTPS,10000000)}</stringProp>
+            <stringProp name="Argument.desc">samples per minute.</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tenantMode" elementType="Argument">
+            <stringProp name="Argument.name">tenantMode</stringProp>
+            <stringProp name="Argument.value">${__P(tenantMode,false)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfTenants" elementType="Argument">
+            <stringProp name="Argument.name">noOfTenants</stringProp>
+            <stringProp name="Argument.value">${__P(noOfTenants,100)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfNodes" elementType="Argument">
+            <stringProp name="Argument.name">noOfNodes</stringProp>
+            <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="deployment" elementType="Argument">
+            <stringProp name="Argument.name">deployment</stringProp>
+            <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Password Grant">
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+        <stringProp name="ThreadGroup.num_threads">${noOfThreads}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${rampUpPeriod}</stringProp>
+        <stringProp name="ThreadGroup.duration">${timeToRun}</stringProp>
+        <longProp name="ThreadGroup.delay">0</longProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <intProp name="LoopController.loops">-1</intProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Tenant Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfTenants}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">tenant_idx</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="SP Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfSPs}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">sp_count_id</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="User Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfUsers}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">user_count_id</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random_sp_count">
+          <stringProp name="maximumValue">${noOfSPs}</stringProp>
+          <stringProp name="minimumValue">1</stringProp>
+          <stringProp name="outputFormat"></stringProp>
+          <boolProp name="perThread">true</boolProp>
+          <stringProp name="randomSeed"></stringProp>
+          <stringProp name="variableName">sp_count_id_random</stringProp>
+        </RandomVariableConfig>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="script">String tenantMode = vars.get(&quot;tenantMode&quot;);
+String consumerKeyPrefix = vars.get(&quot;consumerKeyPrefix&quot;);
+String consumerSecretPrefix = vars.get(&quot;consumerSecretPrefix&quot;);
+String tenantDomainPrefix = vars.get(&quot;tenantDomainPrefix&quot;);
+String tenantIndex = vars.get(&quot;tenant_idx&quot;);
+String sp_count_id_random = vars.get(&quot;sp_count_id_random&quot;);
+String passwordPrefix = vars.get(&quot;passwordPrefix&quot;);
+
+String username = &quot;&quot;;
+String client_secret = &quot;&quot;;
+String client_id = &quot;&quot;;
+String redirect_uri = &quot;&quot;;
+String tokenEndpoint = &quot;&quot;;
+String password = &quot;&quot;;
+
+
+if (new String(tenantMode).equals(&quot;true&quot;)) {
+
+username = &quot;${usernamePrefix}${user_count_id}@${tenantDomainPrefix}${tenant_idx}.com&quot;;
+client_secret = &quot;${consumerSecretPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
+client_id = &quot;${consumerKeyPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
+redirect_uri = &quot;${callback_url_prefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
+password = &quot;${passwordPrefix}${user_count_id}${tenantDomainPrefix}${tenant_idx}&quot;;
+tokenEndpoint = &quot;/t/${tenantDomainPrefix}${tenant_idx}.com/oauth2/token&quot;;
+
+} else {
+
+username = &quot;${usernamePrefix}${user_count_id}&quot;;
+client_secret = &quot;${consumerSecretPrefix}${sp_count_id}&quot;;
+client_id = &quot;${consumerKeyPrefix}${sp_count_id}&quot;;
+redirect_uri = &quot;${callback_url_prefix}${sp_count_id}&quot;;
+password = &quot;${passwordPrefix}${user_count_id}&quot;;
+tokenEndpoint = &quot;/oauth2/token&quot;;
+
+}
+
+vars.put(&quot;username&quot;, new String(username));
+vars.put(&quot;client_secret&quot;, new String(client_secret));
+vars.put(&quot;client_id&quot;, new String(client_id));
+vars.put(&quot;redirect_uri&quot;,new String(redirect_uri));
+vars.put(&quot;password&quot;, new String(password));
+vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()">
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
+int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
+int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int y = x - (x/numOfNodes)*numOfNodes;
+
+if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
+    vars.put(&quot;serverNode&quot;, &quot;node1&quot;);
+} else if (y == 1) {
+    vars.put(&quot;serverNode&quot;, &quot;node2&quot;);
+} else if (y == 2) {
+    vars.put(&quot;serverNode&quot;, &quot;node3&quot;);
+} else {
+    vars.put(&quot;serverNode&quot;, &quot;node4&quot;);
+}</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">X-Server-Select</stringProp>
+              <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 GetToken_Password_Grant">
+          <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">${tokenEndpoint}</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="grant_type" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">password</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">grant_type</stringProp>
+              </elementProp>
+              <elementProp name="username" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${username}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">username</stringProp>
+              </elementProp>
+              <elementProp name="password" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${password}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">password</stringProp>
+              </elementProp>
+              <elementProp name="scope" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${scope}%20device_${__Random(1,10000000)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">scope</stringProp>
+              </elementProp>
+              <elementProp name="client_secret" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${client_secret}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">client_secret</stringProp>
+              </elementProp>
+              <elementProp name="client_id" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">${client_id}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">client_id</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103171775">HTTP/1.1 200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - access token" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="417462488">&quot;access_token&quot;:</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+            <boolProp name="Assertion.assume_success">true</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - id token" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="731531919">&quot;id_token&quot;:</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+            <boolProp name="Assertion.assume_success">true</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+        </hashTree>
+        <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Constant Throughput">
+          <intProp name="calcMode">1</intProp>
+          <stringProp name="throughput">${constantTPS}</stringProp>
+        </ConstantThroughputTimer>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Password Grant" enabled="false">
+        <stringProp name="ThreadGroup.num_threads">${noOfBurst}</stringProp>
+        <intProp name="ThreadGroup.ramp_time">0</intProp>
+        <longProp name="ThreadGroup.duration">180</longProp>
+        <longProp name="ThreadGroup.delay">360</longProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Tenant Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfTenants}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">tenant_idx</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="SP Counter" enabled="true">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${noOfSPs}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">sp_count_id</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random_sp_count" enabled="true">
+          <stringProp name="maximumValue">${noOfSPs}</stringProp>
+          <stringProp name="minimumValue">1</stringProp>
+          <stringProp name="outputFormat"></stringProp>
+          <boolProp name="perThread">true</boolProp>
+          <stringProp name="randomSeed"></stringProp>
+          <stringProp name="variableName">sp_count_id_random</stringProp>
+        </RandomVariableConfig>
+        <hashTree/>
+        <RandomVariableConfig guiclass="TestBeanGUI" testclass="RandomVariableConfig" testname="Random User Counter" enabled="true">
+          <stringProp name="maximumValue">${noOfUsers}</stringProp>
+          <stringProp name="minimumValue">1</stringProp>
+          <stringProp name="outputFormat"></stringProp>
+          <boolProp name="perThread">true</boolProp>
+          <stringProp name="randomSeed"></stringProp>
+          <stringProp name="variableName">user_count_id</stringProp>
+        </RandomVariableConfig>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="script">String tenantMode = vars.get(&quot;tenantMode&quot;);
+String consumerKeyPrefix = vars.get(&quot;consumerKeyPrefix&quot;);
+String consumerSecretPrefix = vars.get(&quot;consumerSecretPrefix&quot;);
+String tenantDomainPrefix = vars.get(&quot;tenantDomainPrefix&quot;);
+String tenantIndex = vars.get(&quot;tenant_idx&quot;);
+String sp_count_id_random = vars.get(&quot;sp_count_id_random&quot;);
+
+String username = &quot;&quot;;
+String client_secret = &quot;&quot;;
+String client_id = &quot;&quot;;
+String redirect_uri = &quot;&quot;;
+String tokenEndpoint = &quot;&quot;;
+
+
+if (new String(tenantMode).equals(&quot;true&quot;)) {
+
+username = &quot;${usernamePrefix}${user_count_id}@${tenantDomainPrefix}${tenant_idx}.com&quot;;
+client_secret = &quot;${consumerSecretPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
+client_id = &quot;${consumerKeyPrefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
+redirect_uri = &quot;${callback_url_prefix}${sp_count_id_random}${tenantDomainPrefix}${tenant_idx}&quot;;
+tokenEndpoint = &quot;/t/${tenantDomainPrefix}${tenant_idx}.com/oauth2/token&quot;;
+
+} else {
+
+username = &quot;${usernamePrefix}${user_count_id}&quot;;
+client_secret = &quot;${consumerSecretPrefix}${sp_count_id}&quot;;
+client_id = &quot;${consumerKeyPrefix}${sp_count_id}&quot;;
+redirect_uri = &quot;${callback_url_prefix}${sp_count_id}&quot;;
+tokenEndpoint = &quot;/oauth2/token&quot;;
+
+}
+
+vars.put(&quot;username&quot;, new String(username));
+vars.put(&quot;client_secret&quot;, new String(client_secret));
+vars.put(&quot;client_id&quot;, new String(client_id));
+vars.put(&quot;redirect_uri&quot;,new String(redirect_uri));
+vars.put(&quot;tokenEndpoint&quot;,new String(tokenEndpoint));</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()" enabled="true">
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
+int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
+int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int y = x - (x/numOfNodes)*numOfNodes;
+
+if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
+    vars.put(&quot;serverNode&quot;, &quot;node1&quot;);
+} else if (y == 1) {
+    vars.put(&quot;serverNode&quot;, &quot;node2&quot;);
+} else if (y == 2) {
+    vars.put(&quot;serverNode&quot;, &quot;node3&quot;);
+} else {
+    vars.put(&quot;serverNode&quot;, &quot;node4&quot;);
+}</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">X-Server-Select</stringProp>
+              <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <IfController guiclass="IfControllerPanel" testclass="IfController" testname="If Controller" enabled="true">
+          <stringProp name="IfController.condition">${__jexl3(&quot;${noOfBurst}&quot; != &quot;0&quot;)}</stringProp>
+          <boolProp name="IfController.evaluateAll">false</boolProp>
+          <boolProp name="IfController.useExpression">true</boolProp>
+        </IfController>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 Burst GetToken_Password_Grant" enabled="true">
+            <stringProp name="TestPlan.comments">/oauth2/token</stringProp>
+            <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+            <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.path">${tokenEndpoint}</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <stringProp name="HTTPSampler.method">POST</stringProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="grant_type" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">password</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">grant_type</stringProp>
+                </elementProp>
+                <elementProp name="username" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">${username}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">username</stringProp>
+                </elementProp>
+                <elementProp name="password" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">${password}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">password</stringProp>
+                </elementProp>
+                <elementProp name="scope" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">${scope}%20device_${__Random(1,10000000)}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">scope</stringProp>
+                </elementProp>
+                <elementProp name="client_secret" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">${client_secret}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">client_secret</stringProp>
+                </elementProp>
+                <elementProp name="client_id" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">${client_id}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+                  <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                  <stringProp name="Argument.name">client_id</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="103171775">HTTP/1.1 200</stringProp>
+              </collectionProp>
+              <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+              <boolProp name="Assertion.assume_success">false</boolProp>
+              <intProp name="Assertion.test_type">2</intProp>
+              <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+            </ResponseAssertion>
+            <hashTree/>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - access token" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="417462488">&quot;access_token&quot;:</stringProp>
+              </collectionProp>
+              <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+              <boolProp name="Assertion.assume_success">true</boolProp>
+              <intProp name="Assertion.test_type">2</intProp>
+              <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+            </ResponseAssertion>
+            <hashTree/>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion - id token" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="731531919">&quot;id_token&quot;:</stringProp>
+              </collectionProp>
+              <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+              <boolProp name="Assertion.assume_success">true</boolProp>
+              <intProp name="Assertion.test_type">2</intProp>
+              <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+            </ResponseAssertion>
+            <hashTree/>
+          </hashTree>
+        </hashTree>
+      </hashTree>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/common/jmeter/setup/TestData_Add_API_Auth_RBAC.jmx
+++ b/common/jmeter/setup/TestData_Add_API_Auth_RBAC.jmx
@@ -50,19 +50,14 @@
             <stringProp name="Argument.value">rbacApp</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
-          <elementProp name="roleNamePrefix" elementType="Argument">
-            <stringProp name="Argument.name">roleNamePrefix</stringProp>
-            <stringProp name="Argument.value">rbacAppRole</stringProp>
-            <stringProp name="Argument.metadata">=</stringProp>
-          </elementProp>
           <elementProp name="consumerKeyPrefix" elementType="Argument">
             <stringProp name="Argument.name">consumerKeyPrefix</stringProp>
-            <stringProp name="Argument.value">rbacConsumerKey</stringProp>
+            <stringProp name="Argument.value">consumerKey</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="consumerSecretPrefix" elementType="Argument">
             <stringProp name="Argument.name">consumerSecretPrefix</stringProp>
-            <stringProp name="Argument.value">rbacConsumerSecret</stringProp>
+            <stringProp name="Argument.value">consumerSecret</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="callbackUrlPrefix" elementType="Argument">
@@ -90,19 +85,19 @@
             <stringProp name="Argument.value">testScope</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
-          <elementProp name="roleDisplayName" elementType="Argument">
-            <stringProp name="Argument.name">roleDisplayName</stringProp>
+          <elementProp name="roleDisplayNamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">roleDisplayNamePrefix</stringProp>
             <stringProp name="Argument.value">testRole</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="usernamePrefix" elementType="Argument">
             <stringProp name="Argument.name">usernamePrefix</stringProp>
-            <stringProp name="Argument.value">testUser</stringProp>
+            <stringProp name="Argument.value">isTestUser</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="userPassword" elementType="Argument">
             <stringProp name="Argument.name">userPassword</stringProp>
-            <stringProp name="Argument.value">testPassword@</stringProp>
+            <stringProp name="Argument.value">Password_1</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="userFirstNamePrefix" elementType="Argument">
@@ -140,9 +135,14 @@
             <stringProp name="Argument.value">${__P(tokenIssuer,Default)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="userCount" elementType="Argument">
+            <stringProp name="Argument.name">userCount</stringProp>
+            <stringProp name="Argument.value">${__P(users,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
           <elementProp name="spCount" elementType="Argument">
             <stringProp name="Argument.name">spCount</stringProp>
-            <stringProp name="Argument.value">${__P(apps,10)}</stringProp>
+            <stringProp name="Argument.value">${__P(noOfSp,10)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -208,17 +208,11 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <boolProp name="resetInterpreter">false</boolProp>
           <stringProp name="parameters"></stringProp>
           <stringProp name="filename"></stringProp>
-          <stringProp name="script">String apiResourceName = vars.get(&quot;apiResourceName&quot;);
-String apiIdentifier = vars.get(&quot;apiIdentifier&quot;);
-String scopeName = vars.get(&quot;scopeName&quot;);
-String scopeDisplayName = vars.get(&quot;scopeDisplayName&quot;);
-String apiResourceDescription = &quot;This is the api resource.&quot;;
+          <stringProp name="script">String apiResourceDescription = &quot;This is the api resource.&quot;;
+String scopeDescription = &quot;This is the scope.&quot;;
 
-vars.put(&quot;apiResourceName&quot;, new String(apiResourceName));
-vars.put(&quot;apiIdentifier&quot;, new String(apiIdentifier));
 vars.put(&quot;apiResourceDescription&quot;, new String(apiResourceDescription));
-vars.put(&quot;scopeName&quot;, new String(scopeName));
-vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringProp>
+vars.put(&quot;scopeDescription&quot;, new String(scopeDescription));</stringProp>
         </BeanShellPreProcessor>
         <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create Api Resource">
@@ -244,7 +238,7 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
 		{&#xd;
 			&quot;name&quot;: &quot;${scopeName}&quot;,&#xd;
 			&quot;displayName&quot;: &quot;${scopeDisplayName}&quot;,&#xd;
-	    		&quot;description&quot;: &quot;This is a sample scope&quot;&#xd;
+	    		&quot;description&quot;: &quot;${scopeDescription}&quot;&#xd;
 		}&#xd;
 	]&#xd;
 }</stringProp>
@@ -281,7 +275,7 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
           <hashTree/>
         </hashTree>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create SP">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create SP and Create User">
         <stringProp name="ThreadGroup.num_threads">${noOfThreads}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">${rampUpPeriod}</stringProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
@@ -310,15 +304,6 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
           <boolProp name="CounterConfig.per_user">false</boolProp>
         </CounterConfig>
         <hashTree/>
-        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="User Index Counter">
-          <stringProp name="CounterConfig.start">1</stringProp>
-          <stringProp name="CounterConfig.end"></stringProp>
-          <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">userIndex</stringProp>
-          <stringProp name="CounterConfig.format"></stringProp>
-          <boolProp name="CounterConfig.per_user">false</boolProp>
-        </CounterConfig>
-        <hashTree/>
         <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager">
           <collectionProp name="CookieManager.cookies"/>
           <boolProp name="CookieManager.clearEachIteration">false</boolProp>
@@ -341,6 +326,27 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
             </elementProp>
           </collectionProp>
         </HeaderManager>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="script">String spNamePrefix = vars.get(&quot;spNamePrefix&quot;);
+String consumerKeyPrefix = vars.get(&quot;consumerKeyPrefix&quot;);
+String consumerSecretPrefix = vars.get(&quot;consumerSecretPrefix&quot;);
+String roleDisplayNamePrefix = vars.get(&quot;roleDisplayNamePrefix&quot;);
+
+String spName = spNamePrefix+&quot;${spCountId}&quot;;
+String consumerKey = consumerKeyPrefix+&quot;${spCountId}&quot;;
+String consumerSecret = consumerSecretPrefix+&quot;${spCountId}&quot;;
+String roleDisplayName = roleDisplayNamePrefix+&quot;${roleCountId}&quot;;
+
+vars.put(&quot;spName&quot;, new String(spName));
+vars.put(&quot;consumerKey&quot;, new String(consumerKey));
+vars.put(&quot;consumerSecret&quot;, new String(consumerSecret));
+vars.put(&quot;roleDisplayName&quot;, new String(roleDisplayName));
+</stringProp>
+        </BeanShellPreProcessor>
         <hashTree/>
         <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()">
           <stringProp name="filename"></stringProp>
@@ -365,7 +371,7 @@ if (y == 0) {
           <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
           <stringProp name="HTTPSampler.port">${is_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
-          <stringProp name="HTTPSampler.path">/api/server/v1/applications</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/api/server/v1/applications</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
@@ -375,7 +381,7 @@ if (y == 0) {
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
-  &quot;name&quot;: &quot;${spNamePrefix}${spCountId}&quot;,&#xd;
+  &quot;name&quot;: &quot;${spName}&quot;,&#xd;
   &quot;description&quot;: &quot;appDesc&quot;,&#xd;
   &quot;claimConfiguration&quot;: {&#xd;
         &quot;dialect&quot;: &quot;LOCAL&quot;,&#xd;
@@ -515,8 +521,8 @@ if (y == 0) {
       },&#xd;
       &quot;scopeValidators&quot;: [],&#xd;
       &quot;validateRequestObjectSignature&quot;: false,&#xd;
-      &quot;clientId&quot;: &quot;${consumerKeyPrefix}${spCountId}&quot;,&#xd;
-      &quot;clientSecret&quot;: &quot;${consumerSecretPrefix}${spCountId}&quot;&#xd;
+      &quot;clientId&quot;: &quot;${consumerKey}&quot;,&#xd;
+      &quot;clientSecret&quot;: &quot;${consumerSecret}&quot;&#xd;
     }&#xd;
   },&#xd;
   &quot;authenticationSequence&quot;: {&#xd;
@@ -568,6 +574,23 @@ if (y == 0) {
               </elementProp>
             </collectionProp>
           </HeaderManager>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">import java.util.ArrayList;
+
+try {
+    ArrayList scimIdList = new ArrayList();
+    vars.putObject(&quot;scimIdList&quot;, scimIdList);
+}
+catch (Exception ex) {
+    log.info(&quot;Error in Beanshell: &quot; + ex.toString());
+    throw ex;
+}
+</stringProp>
+          </BeanShellPostProcessor>
           <hashTree/>
         </hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get SP ID">
@@ -644,11 +667,9 @@ if (y == 0) {
             <stringProp name="filename"></stringProp>
             <stringProp name="script">String apiResourceId = props.get(&quot;apiResourceId&quot;);
 String policyIdentifier = &quot;RBAC&quot;;
-String scopeName = vars.get(&quot;scopeName&quot;);
 
 vars.put(&quot;apiResourceId&quot;, new String(apiResourceId));
-vars.put(&quot;policyIdentifier&quot;, new String(policyIdentifier));
-vars.put(&quot;scopeName&quot;, new String(scopeName));</stringProp>
+vars.put(&quot;policyIdentifier&quot;, new String(policyIdentifier));</stringProp>
           </BeanShellPreProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion">
@@ -682,7 +703,7 @@ vars.put(&quot;scopeName&quot;, new String(scopeName));</stringProp>
   &quot;schemas&quot;: [&#xd;
     &quot;urn:ietf:params:scim:schemas:extension:2.0:Role&quot;&#xd;
   ],&#xd;
-  &quot;displayName&quot;: &quot;${roleDisplayName}${roleCountId}&quot;,&#xd;
+  &quot;displayName&quot;: &quot;${roleDisplayName}&quot;,&#xd;
   &quot;audience&quot;: {&#xd;
     &quot;value&quot;: &quot;${applicationId}&quot;,&#xd;
     &quot;type&quot;: &quot;application&quot;&#xd;
@@ -711,59 +732,47 @@ vars.put(&quot;scopeName&quot;, new String(scopeName));</stringProp>
             <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
-            <boolProp name="resetInterpreter">false</boolProp>
-            <stringProp name="parameters"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="script">String applicationId = vars.get(&quot;applicationId&quot;);
-String roleDisplayNamePrefix = vars.get(&quot;roleDisplayNamePrefix&quot;);
-String scopeName = vars.get(&quot;scopeName&quot;);
-String scopeDisplayName = vars.get(&quot;scopeDisplayName&quot;);
-
-String roleDisplayName = roleDisplayNamePrefix;
-
-vars.put(roleDisplayName, new String(roleDisplayName));
-vars.put(applicationId, new String(applicationId));
-vars.put(scopeName, new String(scopeName));
-vars.put(scopeDisplayName, new String(scopeDisplayName));</stringProp>
-          </BeanShellPreProcessor>
-          <hashTree/>
           <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor">
             <stringProp name="JSONPostProcessor.referenceNames">roleId</stringProp>
             <stringProp name="JSONPostProcessor.jsonPathExprs">$.id</stringProp>
-            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers"></stringProp>
             <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
             <stringProp name="Scope.variable"></stringProp>
           </JSONPostProcessor>
           <hashTree/>
-          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
-            <stringProp name="TestPlan.comments">Write extracted SCIM ID to a csv</stringProp>
-            <boolProp name="resetInterpreter">false</boolProp>
-            <stringProp name="parameters"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="script">props.put(&quot;roleId&quot;, vars.get(&quot;roleId&quot;));</stringProp>
-          </BeanShellPostProcessor>
-          <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create User Account">
-          <stringProp name="HTTPSampler.proxyUser">admin</stringProp>
-          <stringProp name="HTTPSampler.proxyPass">admin</stringProp>
-          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
-          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
-          <stringProp name="HTTPSampler.protocol">https</stringProp>
-          <stringProp name="HTTPSampler.path">/t/carbon.super/scim2/Users</stringProp>
-          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-          <stringProp name="HTTPSampler.method">POST</stringProp>
-          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-            <collectionProp name="Arguments.arguments">
-              <elementProp name="" elementType="HTTPArgument">
-                <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                <stringProp name="Argument.value">{&#xd;
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">${userCount}</stringProp>
+        </LoopController>
+        <hashTree>
+          <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="User Index Counter">
+            <stringProp name="CounterConfig.start">1</stringProp>
+            <stringProp name="CounterConfig.end"></stringProp>
+            <stringProp name="CounterConfig.incr">1</stringProp>
+            <stringProp name="CounterConfig.name">userIndex</stringProp>
+            <stringProp name="CounterConfig.format"></stringProp>
+            <boolProp name="CounterConfig.per_user">true</boolProp>
+          </CounterConfig>
+          <hashTree/>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create User Account">
+            <stringProp name="HTTPSampler.proxyUser">admin</stringProp>
+            <stringProp name="HTTPSampler.proxyPass">admin</stringProp>
+            <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+            <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+            <stringProp name="HTTPSampler.protocol">https</stringProp>
+            <stringProp name="HTTPSampler.path">/t/carbon.super/scim2/Users</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <stringProp name="HTTPSampler.method">POST</stringProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+              <collectionProp name="Arguments.arguments">
+                <elementProp name="" elementType="HTTPArgument">
+                  <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                  <stringProp name="Argument.value">{&#xd;
    &quot;schemas&quot;:[&quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;, &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;, &quot;urn:scim:wso2:schema&quot;],&#xd;
    &quot;userName&quot;:&quot;${usernamePrefix}${userIndex}&quot;,&#xd;
-   &quot;password&quot;:&quot;${userPassword}${userIndex}&quot;,&#xd;
+   &quot;password&quot;:&quot;${userPassword}&quot;,&#xd;
    &quot;name&quot;:{&#xd;
       &quot;familyName&quot;:&quot;${userFirstNamePrefix}${userIndex}&quot;,&#xd;
       &quot;givenName&quot;:&quot;${userLastNamePrefix}${userIndex}&quot;&#xd;
@@ -778,72 +787,74 @@ vars.put(scopeDisplayName, new String(scopeDisplayName));</stringProp>
    },&#xd;
    &quot;roles&quot;:[  &#xd;
       {  &#xd;
-         &quot;type&quot;:&quot;default&quot;,&#xd;
-         &quot;value&quot;:&quot;${roleDisplayName}${roleCountId}&quot;&#xd;
+         &quot;type&quot;:&quot;application&quot;,&#xd;
+         &quot;value&quot;:&quot;${roleDisplayName}&quot;&#xd;
       }&#xd;
    ]&#xd;
 }&#xd;
 </stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-            </collectionProp>
-          </elementProp>
-          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-        </HTTPSamplerProxy>
-        <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion">
-            <collectionProp name="Asserion.test_strings">
-              <stringProp name="-2087731895">&quot;userName&quot;:&quot;${usernamePrefix}${userIndex}&quot;</stringProp>
-            </collectionProp>
-            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
-            <boolProp name="Assertion.assume_success">false</boolProp>
-            <intProp name="Assertion.test_type">2</intProp>
-            <stringProp name="Assertion.custom_message"></stringProp>
-          </ResponseAssertion>
-          <hashTree/>
-          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor">
-            <stringProp name="JSONPostProcessor.referenceNames">userId</stringProp>
-            <stringProp name="JSONPostProcessor.jsonPathExprs">$.id</stringProp>
-            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
-            <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
-            <stringProp name="Scope.variable"></stringProp>
-          </JSONPostProcessor>
-          <hashTree/>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - SCIM ID">
-            <stringProp name="RegexExtractor.useHeaders">false</stringProp>
-            <stringProp name="RegexExtractor.refname">scimID</stringProp>
-            <stringProp name="RegexExtractor.regex">&quot;id&quot;:&quot;(.+?)&quot;</stringProp>
-            <stringProp name="RegexExtractor.template">$1$</stringProp>
-            <stringProp name="RegexExtractor.default">FALSE</stringProp>
-            <stringProp name="RegexExtractor.match_number">0</stringProp>
-            <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
-          </RegexExtractor>
-          <hashTree/>
-          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
-            <stringProp name="TestPlan.comments">Write extracted SCIM ID to a csv</stringProp>
-            <boolProp name="resetInterpreter">false</boolProp>
-            <stringProp name="parameters"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="script">import java.io.FileWriter;
-import java.io.BufferedReader;
+                  <stringProp name="Argument.metadata">=</stringProp>
+                </elementProp>
+              </collectionProp>
+            </elementProp>
+            <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          </HTTPSamplerProxy>
+          <hashTree>
+            <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+              <collectionProp name="Asserion.test_strings">
+                <stringProp name="-2087731895">&quot;userName&quot;:&quot;${usernamePrefix}${userIndex}&quot;</stringProp>
+              </collectionProp>
+              <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+              <boolProp name="Assertion.assume_success">false</boolProp>
+              <intProp name="Assertion.test_type">2</intProp>
+              <stringProp name="Assertion.custom_message"></stringProp>
+            </ResponseAssertion>
+            <hashTree/>
+            <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor" enabled="true">
+              <stringProp name="JSONPostProcessor.referenceNames">userId</stringProp>
+              <stringProp name="JSONPostProcessor.jsonPathExprs">$.id</stringProp>
+              <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+              <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
+              <stringProp name="Scope.variable"></stringProp>
+            </JSONPostProcessor>
+            <hashTree/>
+            <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - USER ID" enabled="true">
+              <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+              <stringProp name="RegexExtractor.refname">userID</stringProp>
+              <stringProp name="RegexExtractor.regex">&quot;id&quot;:&quot;(.+?)&quot;</stringProp>
+              <stringProp name="RegexExtractor.template">$1$</stringProp>
+              <stringProp name="RegexExtractor.default">FALSE</stringProp>
+              <stringProp name="RegexExtractor.match_number">0</stringProp>
+              <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
+            </RegexExtractor>
+            <hashTree/>
+            <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
+              <stringProp name="TestPlan.comments">Write extracted SCIM ID to a csv</stringProp>
+              <boolProp name="resetInterpreter">false</boolProp>
+              <stringProp name="parameters"></stringProp>
+              <stringProp name="filename"></stringProp>
+              <stringProp name="script">import java.util.ArrayList;
 
 try {
-	props.put(&quot;userId&quot;, vars.get(&quot;userId&quot;));
-	String scimID = vars.get(&quot;scimID&quot;);
-	String filePath = vars.get(&quot;scimIdCsvPath&quot;);
-	FileWriter fstream = new FileWriter(filePath, true);
-	BufferedWriter out = new BufferedWriter(fstream);
-	out.write(scimID);
-	out.write(&quot;\n&quot;);
-	out.close();
-	fstream.close();
+    String userID = vars.get(&quot;userID&quot;);
+    ArrayList scimIdList = (ArrayList) vars.getObject(&quot;scimIdList&quot;);
+
+    if (scimIdList == null) {
+        scimIdList = new ArrayList();
+    }
+
+    scimIdList.add(userID);
+    vars.putObject(&quot;scimIdList&quot;, scimIdList);
+    log.info(&quot;Added userID to SCIM ID list: &quot; + userID);
 }
-catch (Throwable ex) {
-   log.info(&quot;Error in Beanshell&quot;, ex);
-   throw ex;
-}</stringProp>
-          </BeanShellPostProcessor>
-          <hashTree/>
+catch (Exception ex) {
+    log.info(&quot;Error in Beanshell: &quot; + ex.toString());
+    throw ex;
+}
+</stringProp>
+            </BeanShellPostProcessor>
+            <hashTree/>
+          </hashTree>
         </hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Assign Role">
           <stringProp name="HTTPSampler.proxyUser">admin</stringProp>
@@ -861,10 +872,12 @@ catch (Throwable ex) {
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
-  &quot;displayName&quot;: &quot;${roleDisplayName}${roleCountId}&quot;,&#xd;
-  &quot;users&quot;: [&#xd;
+  &quot;displayName&quot;: &quot;${roleDisplayName}&quot;,&#xd;
+  &quot;users&quot;: ${usersJsonArray},&#xd;
+  &quot;permissions&quot;: [&#xd;
     {&#xd;
-      &quot;value&quot;: &quot;${userId}&quot;&#xd;
+      &quot;value&quot;: &quot;${scopeName}&quot;,&#xd;
+      &quot;display&quot;: &quot;${scopeDisplayName}&quot;&#xd;
     }&#xd;
   ]&#xd;
 }</stringProp>
@@ -875,17 +888,6 @@ catch (Throwable ex) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
-            <boolProp name="resetInterpreter">false</boolProp>
-            <stringProp name="parameters"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="script">String userId = props.get(&quot;userId)&quot;;
-String roleId = props.get(&quot;roleId&quot;);
-
-vars.put(userId, new String(userId));
-vars.put(roleId, new String(roleId));</stringProp>
-          </BeanShellPreProcessor>
-          <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="200 HTTP Code Response Assertion">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>
@@ -896,45 +898,40 @@ vars.put(roleId, new String(roleId));</stringProp>
             <stringProp name="Assertion.custom_message">Test Failed - Create Role</stringProp>
           </ResponseAssertion>
           <hashTree/>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">import java.util.ArrayList;
+import java.util.List;
+
+try {
+    ArrayList scimIdList = (ArrayList) vars.getObject(&quot;scimIdList&quot;);
+    List usersList = new ArrayList();
+
+    if (scimIdList != null &amp;&amp; !scimIdList.isEmpty()) {
+        for (int i = 0; i &lt; scimIdList.size(); i++) {
+            String scimId = (String) scimIdList.get(i);
+            if (scimId != null &amp;&amp; !scimId.trim().isEmpty()) {
+                usersList.add(&quot;{\&quot;value\&quot;: \&quot;&quot; + scimId.trim() + &quot;\&quot;}&quot;);
+            }
+        }
+    } else {
+        log.info(&quot;SCIM ID list is empty or not initialized.&quot;);
+    }
+
+    String usersJsonArray = usersList.toString().replaceAll(&quot;, &quot;, &quot;,&quot;);
+    vars.put(&quot;usersJsonArray&quot;, usersJsonArray); 
+}
+catch (Exception ex) {
+    log.info(&quot;Error in Beanshell: &quot; + ex.toString());
+    throw ex;
+}
+</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
         </hashTree>
       </hashTree>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
-        <boolProp name="ResultCollector.error_logging">false</boolProp>
-        <objProp>
-          <name>saveConfig</name>
-          <value class="SampleSaveConfiguration">
-            <time>true</time>
-            <latency>true</latency>
-            <timestamp>true</timestamp>
-            <success>true</success>
-            <label>true</label>
-            <code>true</code>
-            <message>true</message>
-            <threadName>true</threadName>
-            <dataType>true</dataType>
-            <encoding>false</encoding>
-            <assertions>true</assertions>
-            <subresults>true</subresults>
-            <responseData>false</responseData>
-            <samplerData>false</samplerData>
-            <xml>false</xml>
-            <fieldNames>true</fieldNames>
-            <responseHeaders>false</responseHeaders>
-            <requestHeaders>false</requestHeaders>
-            <responseDataOnError>false</responseDataOnError>
-            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
-            <assertionsResultsToSave>0</assertionsResultsToSave>
-            <bytes>true</bytes>
-            <sentBytes>true</sentBytes>
-            <url>true</url>
-            <threadCounts>true</threadCounts>
-            <idleTime>true</idleTime>
-            <connectTime>true</connectTime>
-          </value>
-        </objProp>
-        <stringProp name="filename"></stringProp>
-      </ResultCollector>
-      <hashTree/>
     </hashTree>
   </hashTree>
 </jmeterTestPlan>

--- a/common/jmeter/setup/TestData_Add_API_Auth_RBAC.jmx
+++ b/common/jmeter/setup/TestData_Add_API_Auth_RBAC.jmx
@@ -47,22 +47,22 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="spNamePrefix" elementType="Argument">
             <stringProp name="Argument.name">spNamePrefix</stringProp>
-            <stringProp name="Argument.value">rbac_app_</stringProp>
+            <stringProp name="Argument.value">rbacApp</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="roleNamePrefix" elementType="Argument">
             <stringProp name="Argument.name">roleNamePrefix</stringProp>
-            <stringProp name="Argument.value">rbac_AppRole__</stringProp>
+            <stringProp name="Argument.value">rbacAppRole</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="consumerKeyPrefix" elementType="Argument">
             <stringProp name="Argument.name">consumerKeyPrefix</stringProp>
-            <stringProp name="Argument.value">rbac_consumerKey_</stringProp>
+            <stringProp name="Argument.value">rbacConsumerKey</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="consumerSecretPrefix" elementType="Argument">
             <stringProp name="Argument.name">consumerSecretPrefix</stringProp>
-            <stringProp name="Argument.value">rbac_consumerSecret_</stringProp>
+            <stringProp name="Argument.value">rbacConsumerSecret</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="callbackUrlPrefix" elementType="Argument">
@@ -72,7 +72,7 @@
           </elementProp>
           <elementProp name="apiResourceName" elementType="Argument">
             <stringProp name="Argument.name">apiResourceName</stringProp>
-            <stringProp name="Argument.value">test_Api</stringProp>
+            <stringProp name="Argument.value">testApi</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="apiIdentifier" elementType="Argument">
@@ -82,42 +82,42 @@
           </elementProp>
           <elementProp name="scopeName" elementType="Argument">
             <stringProp name="Argument.name">scopeName</stringProp>
-            <stringProp name="Argument.value">testScope_</stringProp>
+            <stringProp name="Argument.value">testScope</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="scopeDisplayName" elementType="Argument">
             <stringProp name="Argument.name">scopeDisplayName</stringProp>
-            <stringProp name="Argument.value">Test Scope_</stringProp>
+            <stringProp name="Argument.value">testScope</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="roleDisplayName" elementType="Argument">
             <stringProp name="Argument.name">roleDisplayName</stringProp>
-            <stringProp name="Argument.value">testRole_</stringProp>
+            <stringProp name="Argument.value">testRole</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="usernamePrefix" elementType="Argument">
             <stringProp name="Argument.name">usernamePrefix</stringProp>
-            <stringProp name="Argument.value">testUser_</stringProp>
+            <stringProp name="Argument.value">testUser</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="userPassword" elementType="Argument">
             <stringProp name="Argument.name">userPassword</stringProp>
-            <stringProp name="Argument.value">testPassword@_</stringProp>
+            <stringProp name="Argument.value">testPassword@</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="userFirstNamePrefix" elementType="Argument">
             <stringProp name="Argument.name">userFirstNamePrefix</stringProp>
-            <stringProp name="Argument.value">isTestUserFirstName_</stringProp>
+            <stringProp name="Argument.value">isTestUserFirstName</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="userLastNamePrefix" elementType="Argument">
             <stringProp name="Argument.name">userLastNamePrefix</stringProp>
-            <stringProp name="Argument.value">isTestUserLastName_</stringProp>
+            <stringProp name="Argument.value">isTestUserLastName</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="useremailPrefix" elementType="Argument">
             <stringProp name="Argument.name">useremailPrefix</stringProp>
-            <stringProp name="Argument.value">istestuser_</stringProp>
+            <stringProp name="Argument.value">isTestUser</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -190,7 +190,7 @@
           <boolProp name="resetInterpreter">false</boolProp>
           <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
 int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
-int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int x = Integer.parseInt(vars.get(&quot;spCountId&quot;));
 int y = x - (x/numOfNodes)*numOfNodes;
 
 if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
@@ -296,7 +296,7 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
           <stringProp name="CounterConfig.start">1</stringProp>
           <stringProp name="CounterConfig.end">${spCount}</stringProp>
           <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">sp_count_id</stringProp>
+          <stringProp name="CounterConfig.name">spCountId</stringProp>
           <stringProp name="CounterConfig.format"></stringProp>
           <boolProp name="CounterConfig.per_user">false</boolProp>
         </CounterConfig>
@@ -305,7 +305,7 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
           <stringProp name="CounterConfig.start">1</stringProp>
           <stringProp name="CounterConfig.end">${spCount}</stringProp>
           <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">role_count_id</stringProp>
+          <stringProp name="CounterConfig.name">roleCountId</stringProp>
           <stringProp name="CounterConfig.format"></stringProp>
           <boolProp name="CounterConfig.per_user">false</boolProp>
         </CounterConfig>
@@ -314,7 +314,7 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
           <stringProp name="CounterConfig.start">1</stringProp>
           <stringProp name="CounterConfig.end"></stringProp>
           <stringProp name="CounterConfig.incr">1</stringProp>
-          <stringProp name="CounterConfig.name">user_index</stringProp>
+          <stringProp name="CounterConfig.name">userIndex</stringProp>
           <stringProp name="CounterConfig.format"></stringProp>
           <boolProp name="CounterConfig.per_user">false</boolProp>
         </CounterConfig>
@@ -347,7 +347,7 @@ vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringPro
           <stringProp name="parameters"></stringProp>
           <boolProp name="resetInterpreter">false</boolProp>
           <stringProp name="script">int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
-int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int x = Integer.parseInt(vars.get(&quot;spCountId&quot;));
 int y = x - (x/numOfNodes)*numOfNodes;
 
 if (y == 0) {
@@ -375,7 +375,7 @@ if (y == 0) {
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
-  &quot;name&quot;: &quot;${spNamePrefix}${sp_count_id}&quot;,&#xd;
+  &quot;name&quot;: &quot;${spNamePrefix}${spCountId}&quot;,&#xd;
   &quot;description&quot;: &quot;appDesc&quot;,&#xd;
   &quot;claimConfiguration&quot;: {&#xd;
         &quot;dialect&quot;: &quot;LOCAL&quot;,&#xd;
@@ -479,7 +479,7 @@ if (y == 0) {
       },&#xd;
       &quot;allowedOrigins&quot;: [],&#xd;
       &quot;callbackURLs&quot;: [&#xd;
-       &quot;${callbackUrlPrefix}${sp_count_id}&quot;&#xd;
+       &quot;${callbackUrlPrefix}${spCountId}&quot;&#xd;
       ],&#xd;
       &quot;grantTypes&quot;: [&#xd;
         &quot;authorization_code&quot;,&#xd;
@@ -515,8 +515,8 @@ if (y == 0) {
       },&#xd;
       &quot;scopeValidators&quot;: [],&#xd;
       &quot;validateRequestObjectSignature&quot;: false,&#xd;
-      &quot;clientId&quot;: &quot;${consumerKeyPrefix}${sp_count_id}&quot;,&#xd;
-      &quot;clientSecret&quot;: &quot;${consumerSecretPrefix}${sp_count_id}&quot;&#xd;
+      &quot;clientId&quot;: &quot;${consumerKeyPrefix}${spCountId}&quot;,&#xd;
+      &quot;clientSecret&quot;: &quot;${consumerSecretPrefix}${spCountId}&quot;&#xd;
     }&#xd;
   },&#xd;
   &quot;authenticationSequence&quot;: {&#xd;
@@ -682,7 +682,7 @@ vars.put(&quot;scopeName&quot;, new String(scopeName));</stringProp>
   &quot;schemas&quot;: [&#xd;
     &quot;urn:ietf:params:scim:schemas:extension:2.0:Role&quot;&#xd;
   ],&#xd;
-  &quot;displayName&quot;: &quot;${roleDisplayName}${role_count_id}&quot;,&#xd;
+  &quot;displayName&quot;: &quot;${roleDisplayName}${roleCountId}&quot;,&#xd;
   &quot;audience&quot;: {&#xd;
     &quot;value&quot;: &quot;${applicationId}&quot;,&#xd;
     &quot;type&quot;: &quot;application&quot;&#xd;
@@ -762,16 +762,16 @@ vars.put(scopeDisplayName, new String(scopeDisplayName));</stringProp>
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
    &quot;schemas&quot;:[&quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;, &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;, &quot;urn:scim:wso2:schema&quot;],&#xd;
-   &quot;userName&quot;:&quot;${usernamePrefix}${user_index}&quot;,&#xd;
-   &quot;password&quot;:&quot;${userPassword}${user_index}&quot;,&#xd;
+   &quot;userName&quot;:&quot;${usernamePrefix}${userIndex}&quot;,&#xd;
+   &quot;password&quot;:&quot;${userPassword}${userIndex}&quot;,&#xd;
    &quot;name&quot;:{&#xd;
-      &quot;familyName&quot;:&quot;${userFirstNamePrefix}${user_index}&quot;,&#xd;
-      &quot;givenName&quot;:&quot;${userLastNamePrefix}${user_index}&quot;&#xd;
+      &quot;familyName&quot;:&quot;${userFirstNamePrefix}${userIndex}&quot;,&#xd;
+      &quot;givenName&quot;:&quot;${userLastNamePrefix}${userIndex}&quot;&#xd;
    },&#xd;
    &quot;wso2Extension&quot;:{&#xd;
       &quot;accountLocked&quot;:&quot;false&quot;&#xd;
    },&#xd;
-   &quot;emails&quot;:[&quot;${useremailPrefix}${user_index}@test.com&quot;],&#xd;
+   &quot;emails&quot;:[&quot;${useremailPrefix}${userIndex}@test.com&quot;],&#xd;
    &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;: &#xd;
    {&#xd;
    		&quot;country&quot;:&quot;Sri Lanka&quot;&#xd;
@@ -779,7 +779,7 @@ vars.put(scopeDisplayName, new String(scopeDisplayName));</stringProp>
    &quot;roles&quot;:[  &#xd;
       {  &#xd;
          &quot;type&quot;:&quot;default&quot;,&#xd;
-         &quot;value&quot;:&quot;${roleDisplayName}${user_index}&quot;&#xd;
+         &quot;value&quot;:&quot;${roleDisplayName}${roleCountId}&quot;&#xd;
       }&#xd;
    ]&#xd;
 }&#xd;
@@ -793,7 +793,7 @@ vars.put(scopeDisplayName, new String(scopeDisplayName));</stringProp>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="-465808698">&quot;userName&quot;:&quot;${usernamePrefix}${user_index}&quot;</stringProp>
+              <stringProp name="-2087731895">&quot;userName&quot;:&quot;${usernamePrefix}${userIndex}&quot;</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
@@ -861,7 +861,7 @@ catch (Throwable ex) {
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
-  &quot;displayName&quot;: &quot;${roleDisplayName}${role_count_id}&quot;,&#xd;
+  &quot;displayName&quot;: &quot;${roleDisplayName}${roleCountId}&quot;,&#xd;
   &quot;users&quot;: [&#xd;
     {&#xd;
       &quot;value&quot;: &quot;${userId}&quot;&#xd;

--- a/common/jmeter/setup/TestData_Add_API_Auth_RBAC.jmx
+++ b/common/jmeter/setup/TestData_Add_API_Auth_RBAC.jmx
@@ -1,0 +1,940 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Add API Authorized Application Roles">
+      <boolProp name="TestPlan.serialize_threadgroups">true</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Server Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="is_host" elementType="Argument">
+            <stringProp name="Argument.name">is_host</stringProp>
+            <stringProp name="Argument.value">${__P(host,localhost)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="is_port" elementType="Argument">
+            <stringProp name="Argument.name">is_port</stringProp>
+            <stringProp name="Argument.value">${__P(port,9443)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="adminCredentials" elementType="Argument">
+            <stringProp name="Argument.name">adminCredentials</stringProp>
+            <stringProp name="Argument.value">${__P(adminCredentials,YWRtaW46YWRtaW4=)} </stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="serverNode" elementType="Argument">
+            <stringProp name="Argument.name">serverNode</stringProp>
+            <stringProp name="Argument.value">${__P(serverNode,node1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="deployment" elementType="Argument">
+            <stringProp name="Argument.name">deployment</stringProp>
+            <stringProp name="Argument.value">${__P(deployment,active-passive)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="noOfNodes" elementType="Argument">
+            <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
+            <stringProp name="Argument.name">noOfNodes</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Test Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="spNamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">spNamePrefix</stringProp>
+            <stringProp name="Argument.value">rbac_app_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="roleNamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">roleNamePrefix</stringProp>
+            <stringProp name="Argument.value">rbac_AppRole__</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="consumerKeyPrefix" elementType="Argument">
+            <stringProp name="Argument.name">consumerKeyPrefix</stringProp>
+            <stringProp name="Argument.value">rbac_consumerKey_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="consumerSecretPrefix" elementType="Argument">
+            <stringProp name="Argument.name">consumerSecretPrefix</stringProp>
+            <stringProp name="Argument.value">rbac_consumerSecret_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="callbackUrlPrefix" elementType="Argument">
+            <stringProp name="Argument.name">callbackUrlPrefix</stringProp>
+            <stringProp name="Argument.value">https://localhost/callback</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="apiResourceName" elementType="Argument">
+            <stringProp name="Argument.name">apiResourceName</stringProp>
+            <stringProp name="Argument.value">test_Api</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="apiIdentifier" elementType="Argument">
+            <stringProp name="Argument.name">apiIdentifier</stringProp>
+            <stringProp name="Argument.value">https://api.test.com</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="scopeName" elementType="Argument">
+            <stringProp name="Argument.name">scopeName</stringProp>
+            <stringProp name="Argument.value">testScope_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="scopeDisplayName" elementType="Argument">
+            <stringProp name="Argument.name">scopeDisplayName</stringProp>
+            <stringProp name="Argument.value">Test Scope_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="roleDisplayName" elementType="Argument">
+            <stringProp name="Argument.name">roleDisplayName</stringProp>
+            <stringProp name="Argument.value">testRole_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="usernamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">usernamePrefix</stringProp>
+            <stringProp name="Argument.value">testUser_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="userPassword" elementType="Argument">
+            <stringProp name="Argument.name">userPassword</stringProp>
+            <stringProp name="Argument.value">testPassword@_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="userFirstNamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">userFirstNamePrefix</stringProp>
+            <stringProp name="Argument.value">isTestUserFirstName_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="userLastNamePrefix" elementType="Argument">
+            <stringProp name="Argument.name">userLastNamePrefix</stringProp>
+            <stringProp name="Argument.value">isTestUserLastName_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="useremailPrefix" elementType="Argument">
+            <stringProp name="Argument.name">useremailPrefix</stringProp>
+            <stringProp name="Argument.value">istestuser_</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="noOfThreads" elementType="Argument">
+            <stringProp name="Argument.name">noOfThreads</stringProp>
+            <stringProp name="Argument.value">${__P(concurrency,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="rampUpPeriod" elementType="Argument">
+            <stringProp name="Argument.name">rampUpPeriod</stringProp>
+            <stringProp name="Argument.value">${__P(rampUpPeriod,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="tokenIssuer" elementType="Argument">
+            <stringProp name="Argument.name">tokenIssuer</stringProp>
+            <stringProp name="Argument.value">${__P(tokenIssuer,Default)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="spCount" elementType="Argument">
+            <stringProp name="Argument.name">spCount</stringProp>
+            <stringProp name="Argument.value">${__P(apps,10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create API Resource">
+        <stringProp name="ThreadGroup.num_threads">${noOfThreads}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${rampUpPeriod}</stringProp>
+        <longProp name="ThreadGroup.duration">3600</longProp>
+        <longProp name="ThreadGroup.delay">10</longProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">startnextloop</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager">
+          <collectionProp name="CookieManager.cookies"/>
+          <boolProp name="CookieManager.clearEachIteration">true</boolProp>
+          <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
+        </CookieManager>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Content-Type</stringProp>
+              <stringProp name="Header.value">application/json</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Basic ${adminCredentials}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">X-Server-Select</stringProp>
+              <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()">
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="script">String deploymentType = vars.get(&quot;deployment&quot;);
+int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
+int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int y = x - (x/numOfNodes)*numOfNodes;
+
+if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
+    vars.put(&quot;serverNode&quot;, &quot;node1&quot;);
+} else if (y == 1) {
+    vars.put(&quot;serverNode&quot;, &quot;node2&quot;);
+} else if (y == 2) {
+    vars.put(&quot;serverNode&quot;, &quot;node3&quot;);
+} else {
+    vars.put(&quot;serverNode&quot;, &quot;node4&quot;);
+}</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="script">String apiResourceName = vars.get(&quot;apiResourceName&quot;);
+String apiIdentifier = vars.get(&quot;apiIdentifier&quot;);
+String scopeName = vars.get(&quot;scopeName&quot;);
+String scopeDisplayName = vars.get(&quot;scopeDisplayName&quot;);
+String apiResourceDescription = &quot;This is the api resource.&quot;;
+
+vars.put(&quot;apiResourceName&quot;, new String(apiResourceName));
+vars.put(&quot;apiIdentifier&quot;, new String(apiIdentifier));
+vars.put(&quot;apiResourceDescription&quot;, new String(apiResourceDescription));
+vars.put(&quot;scopeName&quot;, new String(scopeName));
+vars.put(&quot;scopeDisplayName&quot;, new String(scopeDisplayName));</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create Api Resource">
+          <intProp name="HTTPSampler.concurrentPool">6</intProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/api/server/v1/api-resources</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+	&quot;name&quot;: &quot;${apiResourceName}&quot;,&#xd;
+	&quot;identifier&quot; : &quot;${apiIdentifier}&quot;,&#xd;
+	&quot;description&quot;: &quot;${apiResourceDescription}&quot;,&#xd;
+	&quot;requiresAuthorization&quot;: true,&#xd;
+	&quot;scopes&quot; : [&#xd;
+		{&#xd;
+			&quot;name&quot;: &quot;${scopeName}&quot;,&#xd;
+			&quot;displayName&quot;: &quot;${scopeDisplayName}&quot;,&#xd;
+	    		&quot;description&quot;: &quot;This is a sample scope&quot;&#xd;
+		}&#xd;
+	]&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 201 Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103171776">HTTP/1.1 201</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - common auth login</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor">
+            <stringProp name="JSONPostProcessor.referenceNames">apiResourceId</stringProp>
+            <stringProp name="JSONPostProcessor.jsonPathExprs">$.id</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+            <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
+          </JSONPostProcessor>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">props.put(&quot;apiResourceId&quot;, vars.get(&quot;apiResourceId&quot;));</stringProp>
+          </BeanShellPostProcessor>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create SP">
+        <stringProp name="ThreadGroup.num_threads">${noOfThreads}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${rampUpPeriod}</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">${spCount}</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="SP Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${spCount}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">sp_count_id</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="Role Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end">${spCount}</stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">role_count_id</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <CounterConfig guiclass="CounterConfigGui" testclass="CounterConfig" testname="User Index Counter">
+          <stringProp name="CounterConfig.start">1</stringProp>
+          <stringProp name="CounterConfig.end"></stringProp>
+          <stringProp name="CounterConfig.incr">1</stringProp>
+          <stringProp name="CounterConfig.name">user_index</stringProp>
+          <stringProp name="CounterConfig.format"></stringProp>
+          <boolProp name="CounterConfig.per_user">false</boolProp>
+        </CounterConfig>
+        <hashTree/>
+        <CookieManager guiclass="CookiePanel" testclass="CookieManager" testname="HTTP Cookie Manager">
+          <collectionProp name="CookieManager.cookies"/>
+          <boolProp name="CookieManager.clearEachIteration">false</boolProp>
+          <boolProp name="CookieManager.controlledByThreadGroup">false</boolProp>
+        </CookieManager>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Authorization</stringProp>
+              <stringProp name="Header.value">Basic ${adminCredentials}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Content-Type</stringProp>
+              <stringProp name="Header.value">application/json</stringProp>
+            </elementProp>
+            <elementProp name="X-Server-Select" elementType="Header">
+              <stringProp name="Header.name">X-Server-Select</stringProp>
+              <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="setRequestingNode()">
+          <stringProp name="filename"></stringProp>
+          <stringProp name="parameters"></stringProp>
+          <boolProp name="resetInterpreter">false</boolProp>
+          <stringProp name="script">int numOfNodes = Integer.parseInt(vars.get(&quot;noOfNodes&quot;));
+int x = Integer.parseInt(vars.get(&quot;sp_count_id&quot;));
+int y = x - (x/numOfNodes)*numOfNodes;
+
+if (y == 0) {
+    vars.put(&quot;serverNode&quot;, &quot;node1&quot;);
+} else if (y == 1) {
+    vars.put(&quot;serverNode&quot;, &quot;node2&quot;);
+} else if (y == 2) {
+    vars.put(&quot;serverNode&quot;, &quot;node3&quot;);
+} else {
+    vars.put(&quot;serverNode&quot;, &quot;node4&quot;);
+}</stringProp>
+        </BeanShellPreProcessor>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create SP">
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/api/server/v1/applications</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+  &quot;name&quot;: &quot;${spNamePrefix}${sp_count_id}&quot;,&#xd;
+  &quot;description&quot;: &quot;appDesc&quot;,&#xd;
+  &quot;claimConfiguration&quot;: {&#xd;
+        &quot;dialect&quot;: &quot;LOCAL&quot;,&#xd;
+        &quot;claimMappings&quot;: [&#xd;
+            {&#xd;
+                &quot;applicationClaim&quot;: &quot;http://wso2.org/claims/roles&quot;,&#xd;
+                &quot;localClaim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/roles&quot;&#xd;
+                }&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;applicationClaim&quot;: &quot;http://wso2.org/claims/country&quot;,&#xd;
+                &quot;localClaim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/country&quot;&#xd;
+                }&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;applicationClaim&quot;: &quot;http://wso2.org/claims/emailaddress&quot;,&#xd;
+                &quot;localClaim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/emailaddress&quot;&#xd;
+                }&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;applicationClaim&quot;: &quot;http://wso2.org/claims/groups&quot;,&#xd;
+                &quot;localClaim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/groups&quot;&#xd;
+                }&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;applicationClaim&quot;: &quot;http://wso2.org/claims/givenname&quot;,&#xd;
+                &quot;localClaim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/givenname&quot;&#xd;
+                }&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;applicationClaim&quot;: &quot;http://wso2.org/claims/lastname&quot;,&#xd;
+                &quot;localClaim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/lastname&quot;&#xd;
+                }&#xd;
+            }&#xd;
+        ],&#xd;
+        &quot;requestedClaims&quot;: [&#xd;
+            {&#xd;
+                &quot;claim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/roles&quot;&#xd;
+                },&#xd;
+                &quot;mandatory&quot;: true&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;claim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/country&quot;&#xd;
+                },&#xd;
+                &quot;mandatory&quot;: true&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;claim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/emailaddress&quot;&#xd;
+                },&#xd;
+                &quot;mandatory&quot;: true&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;claim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/groups&quot;&#xd;
+                },&#xd;
+                &quot;mandatory&quot;: true&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;claim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/givenname&quot;&#xd;
+                },&#xd;
+                &quot;mandatory&quot;: true&#xd;
+            },&#xd;
+            {&#xd;
+                &quot;claim&quot;: {&#xd;
+                    &quot;uri&quot;: &quot;http://wso2.org/claims/lastname&quot;&#xd;
+                },&#xd;
+                &quot;mandatory&quot;: true&#xd;
+            }&#xd;
+        ],&#xd;
+        &quot;subject&quot;: {&#xd;
+            &quot;claim&quot;: {&#xd;
+                &quot;uri&quot;: &quot;http://wso2.org/claims/username&quot;&#xd;
+            },&#xd;
+            &quot;includeUserDomain&quot;: false,&#xd;
+            &quot;includeTenantDomain&quot;: false,&#xd;
+            &quot;useMappedLocalSubject&quot;: false&#xd;
+        },&#xd;
+        &quot;role&quot;: {&#xd;
+            &quot;includeUserDomain&quot;: true&#xd;
+        }&#xd;
+    },&#xd;
+  &quot;inboundProtocolConfiguration&quot;: {&#xd;
+    &quot;oidc&quot;: {&#xd;
+      &quot;accessToken&quot;: {&#xd;
+        &quot;type&quot;: &quot;${tokenIssuer}&quot;,&#xd;
+        &quot;userAccessTokenExpiryInSeconds&quot;: 3600,&#xd;
+        &quot;applicationAccessTokenExpiryInSeconds&quot;: 3600,&#xd;
+        &quot;bindingType&quot;: &quot;sso-session&quot;,&#xd;
+        &quot;revokeTokensWhenIDPSessionTerminated&quot;: false,&#xd;
+        &quot;validateTokenBinding&quot;: false&#xd;
+      },&#xd;
+      &quot;allowedOrigins&quot;: [],&#xd;
+      &quot;callbackURLs&quot;: [&#xd;
+       &quot;${callbackUrlPrefix}${sp_count_id}&quot;&#xd;
+      ],&#xd;
+      &quot;grantTypes&quot;: [&#xd;
+        &quot;authorization_code&quot;,&#xd;
+        &quot;implicit&quot;,&#xd;
+        &quot;password&quot;,&#xd;
+        &quot;client_credentials&quot;,&#xd;
+        &quot;refresh_token&quot;,&#xd;
+        &quot;urn:ietf:params:oauth:grant-type:saml2-bearer&quot;,&#xd;
+        &quot;urn:ietf:params:oauth:grant-type:jwt-bearer&quot;,&#xd;
+        &quot;iwa:ntlm&quot;&#xd;
+      ],&#xd;
+      &quot;idToken&quot;: {&#xd;
+        &quot;audience&quot;: [&#xd;
+          &quot;https://localhost:9443/oauth2/token&quot;&#xd;
+        ],&#xd;
+        &quot;encryption&quot;: {&#xd;
+          &quot;algorithm&quot;: &quot;&quot;,&#xd;
+          &quot;enabled&quot;: false,&#xd;
+          &quot;method&quot;: &quot;&quot;&#xd;
+        },&#xd;
+        &quot;expiryInSeconds&quot;: 3600&#xd;
+      },&#xd;
+      &quot;logout&quot;: {&#xd;
+      },&#xd;
+      &quot;pkce&quot;: {&#xd;
+        &quot;mandatory&quot;: false,&#xd;
+        &quot;supportPlainTransformAlgorithm&quot;: true&#xd;
+      },&#xd;
+      &quot;publicClient&quot;: false,&#xd;
+      &quot;refreshToken&quot;: {&#xd;
+        &quot;expiryInSeconds&quot;: 86400,&#xd;
+        &quot;renewRefreshToken&quot;: true&#xd;
+      },&#xd;
+      &quot;scopeValidators&quot;: [],&#xd;
+      &quot;validateRequestObjectSignature&quot;: false,&#xd;
+      &quot;clientId&quot;: &quot;${consumerKeyPrefix}${sp_count_id}&quot;,&#xd;
+      &quot;clientSecret&quot;: &quot;${consumerSecretPrefix}${sp_count_id}&quot;&#xd;
+    }&#xd;
+  },&#xd;
+  &quot;authenticationSequence&quot;: {&#xd;
+    &quot;type&quot;: &quot;DEFAULT&quot;,&#xd;
+    &quot;steps&quot;: [&#xd;
+      {&#xd;
+        &quot;id&quot;: 1,&#xd;
+        &quot;options&quot;: [&#xd;
+          {&#xd;
+            &quot;idp&quot;: &quot;LOCAL&quot;,&#xd;
+            &quot;authenticator&quot;: &quot;BasicAuthenticator&quot;&#xd;
+          }&#xd;
+        ]&#xd;
+      }&#xd;
+    ],&#xd;
+    &quot;requestPathAuthenticators&quot;: [&#xd;
+    &quot;BasicAuthRequestPathAuthenticator&quot;],&#xd;
+    &quot;subjectStepId&quot;: 1,&#xd;
+    &quot;attributeStepId&quot;: 1&#xd;
+  },&#xd;
+  &quot;provisioningConfigurations&quot;: {&#xd;
+    &quot;inboundProvisioning&quot;: {&#xd;
+      &quot;provisioningUserstoreDomain&quot;: &quot;PRIMARY&quot;&#xd;
+    }&#xd;
+  }&#xd;
+}&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="200 HTTP Code Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103171776">HTTP/1.1 201</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">application/json</stringProp>
+              </elementProp>
+            </collectionProp>
+          </HeaderManager>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get SP ID">
+          <intProp name="HTTPSampler.concurrentPool">6</intProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/api/server/v1/applications</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103171775">HTTP/1.1 200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test failed - common auth login</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor">
+            <stringProp name="JSONPostProcessor.referenceNames">applicationId</stringProp>
+            <stringProp name="JSONPostProcessor.jsonPathExprs">$.applications[0].id</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+            <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
+            <stringProp name="Scope.variable"></stringProp>
+          </JSONPostProcessor>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">props.put(&quot;applicationId&quot;, vars.get(&quot;applicationId&quot;));
+</stringProp>
+          </BeanShellPostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Register SCIM2 User API resource with shared SP">
+          <intProp name="HTTPSampler.concurrentPool">6</intProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/api/server/v1/applications/${applicationId}/authorized-apis</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+	&quot;id&quot;: &quot;${apiResourceId}&quot;,&#xd;
+	&quot;policyIdentifier&quot;: &quot;${policyIdentifier}&quot;,&#xd;
+	&quot;scopes&quot;:[&quot;${scopeName}&quot;]&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">String apiResourceId = props.get(&quot;apiResourceId&quot;);
+String policyIdentifier = &quot;RBAC&quot;;
+String scopeName = vars.get(&quot;scopeName&quot;);
+
+vars.put(&quot;apiResourceId&quot;, new String(apiResourceId));
+vars.put(&quot;policyIdentifier&quot;, new String(policyIdentifier));
+vars.put(&quot;scopeName&quot;, new String(scopeName));</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="49586">200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.scope">all</stringProp>
+            <stringProp name="Assertion.custom_message">Test failed - get token</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create Role">
+          <stringProp name="HTTPSampler.proxyUser">admin</stringProp>
+          <stringProp name="HTTPSampler.proxyPass">admin</stringProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/scim2/v2/Roles</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+  &quot;schemas&quot;: [&#xd;
+    &quot;urn:ietf:params:scim:schemas:extension:2.0:Role&quot;&#xd;
+  ],&#xd;
+  &quot;displayName&quot;: &quot;${roleDisplayName}${role_count_id}&quot;,&#xd;
+  &quot;audience&quot;: {&#xd;
+    &quot;value&quot;: &quot;${applicationId}&quot;,&#xd;
+    &quot;type&quot;: &quot;application&quot;&#xd;
+  },&#xd;
+  &quot;permissions&quot;: [&#xd;
+    {&#xd;
+      &quot;value&quot;: &quot;${scopeName}&quot;,&#xd;
+      &quot;display&quot;: &quot;${scopeDisplayName}&quot;&#xd;
+    }&#xd;
+  ]&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 201 Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103171776">HTTP/1.1 201</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">String applicationId = vars.get(&quot;applicationId&quot;);
+String roleDisplayNamePrefix = vars.get(&quot;roleDisplayNamePrefix&quot;);
+String scopeName = vars.get(&quot;scopeName&quot;);
+String scopeDisplayName = vars.get(&quot;scopeDisplayName&quot;);
+
+String roleDisplayName = roleDisplayNamePrefix;
+
+vars.put(roleDisplayName, new String(roleDisplayName));
+vars.put(applicationId, new String(applicationId));
+vars.put(scopeName, new String(scopeName));
+vars.put(scopeDisplayName, new String(scopeDisplayName));</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor">
+            <stringProp name="JSONPostProcessor.referenceNames">roleId</stringProp>
+            <stringProp name="JSONPostProcessor.jsonPathExprs">$.id</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+            <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
+            <stringProp name="Scope.variable"></stringProp>
+          </JSONPostProcessor>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
+            <stringProp name="TestPlan.comments">Write extracted SCIM ID to a csv</stringProp>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">props.put(&quot;roleId&quot;, vars.get(&quot;roleId&quot;));</stringProp>
+          </BeanShellPostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create User Account">
+          <stringProp name="HTTPSampler.proxyUser">admin</stringProp>
+          <stringProp name="HTTPSampler.proxyPass">admin</stringProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/scim2/Users</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+   &quot;schemas&quot;:[&quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;, &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;, &quot;urn:scim:wso2:schema&quot;],&#xd;
+   &quot;userName&quot;:&quot;${usernamePrefix}${user_index}&quot;,&#xd;
+   &quot;password&quot;:&quot;${userPassword}${user_index}&quot;,&#xd;
+   &quot;name&quot;:{&#xd;
+      &quot;familyName&quot;:&quot;${userFirstNamePrefix}${user_index}&quot;,&#xd;
+      &quot;givenName&quot;:&quot;${userLastNamePrefix}${user_index}&quot;&#xd;
+   },&#xd;
+   &quot;wso2Extension&quot;:{&#xd;
+      &quot;accountLocked&quot;:&quot;false&quot;&#xd;
+   },&#xd;
+   &quot;emails&quot;:[&quot;${useremailPrefix}${user_index}@test.com&quot;],&#xd;
+   &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;: &#xd;
+   {&#xd;
+   		&quot;country&quot;:&quot;Sri Lanka&quot;&#xd;
+   },&#xd;
+   &quot;roles&quot;:[  &#xd;
+      {  &#xd;
+         &quot;type&quot;:&quot;default&quot;,&#xd;
+         &quot;value&quot;:&quot;${roleDisplayName}${user_index}&quot;&#xd;
+      }&#xd;
+   ]&#xd;
+}&#xd;
+</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-465808698">&quot;userName&quot;:&quot;${usernamePrefix}${user_index}&quot;</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor">
+            <stringProp name="JSONPostProcessor.referenceNames">userId</stringProp>
+            <stringProp name="JSONPostProcessor.jsonPathExprs">$.id</stringProp>
+            <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
+            <stringProp name="JSONPostProcessor.defaultValues">None</stringProp>
+            <stringProp name="Scope.variable"></stringProp>
+          </JSONPostProcessor>
+          <hashTree/>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - SCIM ID">
+            <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+            <stringProp name="RegexExtractor.refname">scimID</stringProp>
+            <stringProp name="RegexExtractor.regex">&quot;id&quot;:&quot;(.+?)&quot;</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default">FALSE</stringProp>
+            <stringProp name="RegexExtractor.match_number">0</stringProp>
+            <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
+          </RegexExtractor>
+          <hashTree/>
+          <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor">
+            <stringProp name="TestPlan.comments">Write extracted SCIM ID to a csv</stringProp>
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">import java.io.FileWriter;
+import java.io.BufferedReader;
+
+try {
+	props.put(&quot;userId&quot;, vars.get(&quot;userId&quot;));
+	String scimID = vars.get(&quot;scimID&quot;);
+	String filePath = vars.get(&quot;scimIdCsvPath&quot;);
+	FileWriter fstream = new FileWriter(filePath, true);
+	BufferedWriter out = new BufferedWriter(fstream);
+	out.write(scimID);
+	out.write(&quot;\n&quot;);
+	out.close();
+	fstream.close();
+}
+catch (Throwable ex) {
+   log.info(&quot;Error in Beanshell&quot;, ex);
+   throw ex;
+}</stringProp>
+          </BeanShellPostProcessor>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Assign Role">
+          <stringProp name="HTTPSampler.proxyUser">admin</stringProp>
+          <stringProp name="HTTPSampler.proxyPass">admin</stringProp>
+          <stringProp name="HTTPSampler.domain">${is_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${is_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/t/carbon.super/scim2/v2/Roles/${roleId}</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">PUT</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+  &quot;displayName&quot;: &quot;${roleDisplayName}${role_count_id}&quot;,&#xd;
+  &quot;users&quot;: [&#xd;
+    {&#xd;
+      &quot;value&quot;: &quot;${userId}&quot;&#xd;
+    }&#xd;
+  ]&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="BeanShell PreProcessor">
+            <boolProp name="resetInterpreter">false</boolProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="script">String userId = props.get(&quot;userId)&quot;;
+String roleId = props.get(&quot;roleId&quot;);
+
+vars.put(userId, new String(userId));
+vars.put(roleId, new String(roleId));</stringProp>
+          </BeanShellPreProcessor>
+          <hashTree/>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="200 HTTP Code Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="103171775">HTTP/1.1 200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message">Test Failed - Create Role</stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
### Purpose

Onboarding a new JMeter script designed for OIDC Password Grant Validation with Hybrid Flow. This script supports comprehensive testing and benchmarking of password grants with a common auth ID using the hybrid flow.

### Goals

The script automates the following tasks:

1. **Authorization Request**: Sends a request to the authorization endpoint with client credentials (username and password) to obtain the common auth ID using the hybrid flow.
2. **Handle 302 Redirection**: Extracts the common auth ID from the response headers after handling the 302 redirection.
3. **Token Request**: Utilizes the extracted common auth ID in cookies to send a token request to the authorization endpoint without needing to provide username and password again. Validates the response for the necessary tokens.

- Variable for "Remember Me" Feature: Introduces a JMeter variable named chkRemember to toggle the "remember me" feature on or off. Set to true to enable or false to disable.