### PR TITLE
Upgrading JDK to 21

### DIFF
--- a/single-node/single-node.yaml
+++ b/single-node/single-node.yaml
@@ -376,7 +376,7 @@ Resources:
             - apt-get update
             - DEBIAN_FRONTEND=noninteractive apt-get install -yq mysql-client
             - DEBIAN_FRONTEND=noninteractive apt-get install -y unzip
-            - curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-11.0.15.1_linux-x64_bin.tar.gz
+            - curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/OpenJDK21U-jdk_x64_linux_hotspot_21.0.5_11.tar.gz
             - sudo mkdir /usr/lib/jvm
             - sudo tar -xvf jdk-setup.tar.gz -C /usr/lib/jvm
             - sudo mv /usr/lib/jvm/jdk* /usr/lib/jvm/jdk


### PR DESCRIPTION
Using the 21 JDK version in EC2 for perf testing. Only for single node as the first phase.

Related issue:
- https://github.com/wso2/product-is/issues/21158