### PR TITLE
Refactor cloudformation scripts and remove unused params

### DIFF
--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -23,7 +23,6 @@ timestamp=$(date +%Y-%m-%d--%H-%M-%S)
 random_number=$RANDOM
 
 key_file=""
-certificate_name=""
 jmeter_setup=""
 is_setup=""
 default_db_username="wso2carbon"
@@ -52,13 +51,12 @@ minimum_stack_creation_wait_time="$default_minimum_stack_creation_wait_time"
 function usage() {
     echo ""
     echo "Usage: "
-    echo "$0 -k <key_file> -c <certificate_name> -j <jmeter_setup_path> -n <IS_zip_file_path>"
+    echo "$0 -k <key_file> -j <jmeter_setup_path> -n <IS_zip_file_path>"
     echo "   [-u <db_username>] [-p <db_password>] [-d <db_storage>] [-s <session_db_storage>] [-e <db_instance_type>]"
     echo "   [-i <wso2_is_instance_type>] [-b <bastion_instance_type>]"
     echo "   [-w <minimum_stack_creation_wait_time>] [-h]"
     echo ""
     echo "-k: The Amazon EC2 key file to be used to access the instances."
-    echo "-c: The name of the IAM certificate."
     echo "-y: The token issuer type."
     echo "-q: User tag who triggered the Jenkins build"
     echo "-r: Concurrency type (50-500, 500-3000, 50-3000)"
@@ -99,16 +97,13 @@ function execute_db_command() {
     ssh_bastion_cmd "$db_command"
 }
 
-while getopts "q:k:c:j:n:u:p:d:e:i:b:w:s:t:g:m:h" opts; do
+while getopts "q:k:j:n:u:p:d:e:i:b:w:s:t:g:m:h" opts; do
     case $opts in
     q)
         user_tag=${OPTARG}
         ;;
     k)
         key_file=${OPTARG}
-        ;;
-    c)
-        certificate_name=${OPTARG}
         ;;
     j)
         jmeter_setup=${OPTARG}
@@ -200,11 +195,6 @@ fi
 
 if [[ -z $jmeter_setup ]]; then
     echo "Please provide the path to JMeter setup."
-    exit 1
-fi
-
-if [[ -z $certificate_name ]]; then
-    echo "Please provide the name of the IAM certificate."
     exit 1
 fi
 
@@ -303,7 +293,6 @@ stack_create_start_time=$(date +%s)
 stack_name="is-performance-$no_of_nodes_string-node--$timestamp--$random_number"
 create_stack_command="aws cloudformation create-stack --stack-name $stack_name \
     --template-body file://$template_file_name --parameters \
-        ParameterKey=CertificateName,ParameterValue=$certificate_name \
         ParameterKey=KeyPairName,ParameterValue=$key_name \
         ParameterKey=DBUsername,ParameterValue=$db_username \
         ParameterKey=DBPassword,ParameterValue=$db_password \

--- a/four-node-cluster/4-node-cluster.yml
+++ b/four-node-cluster/4-node-cluster.yml
@@ -27,17 +27,11 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
-          - OSType
-      - Label:
-          default: Network Configuration
-        Parameters:
-          - CertificateName
       - Label:
           default: Database Credentials
         Parameters:
           - DBUsername
           - DBPassword
-          - DBEngine
           - DBInstanceType
           - DBAllocationStorage
           - DBIops
@@ -47,18 +41,14 @@ Metadata:
         Parameters:
           - SessionDBUsername
           - SessionDBPassword
-          - SessionDBEngine
           - SessionDBInstanceType
           - SessionDBAllocationStorage
           - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
-          - JDK
           - UserTag
     ParameterLabels:
-      CertificateName:
-        default: SSL Certificate Name
       KeyPairName:
         default: Key Pair Name
       DBUsername:
@@ -69,14 +59,10 @@ Metadata:
         default: Username
       SessionDBPassword:
         default: Password
-      JDK:
-        default: JDK Version
       UserTag:
         default: User Tag
       WSO2InstanceType:
         default: Instance Type
-      DBEngine:
-        default: DB Engine
       DBAllocationStorage:
         default: Allocation Storage
       DBIops:
@@ -85,18 +71,12 @@ Metadata:
         default: DB Instance Type
       DBType:
         default: DB Type
-      SessionDBEngine:
-        default: Session DB Engine
       SessionDBAllocationStorage:
         default: Session DB Allocation Storage
       SessionDBIops:
         default: Session DB Allocation IOPS
       SessionDBInstanceType:
         default: Session DB Instance Type
-      JDKVersion:
-        default: JDK Version
-      OSType:
-        default: OS Type
       BastionInstanceType:
         default: Bastion Instance Type
 Resources:
@@ -267,8 +247,8 @@ Resources:
       GroupDescription: DB Security Group2
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISSessionDBInstanceSecurityGroupsuffix:
     Type: 'AWS::EC2::SecurityGroup'
@@ -277,8 +257,8 @@ Resources:
       GroupDescription: Session DB Security Group
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -290,17 +270,17 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_2 ]
-      EngineVersion: !If [ IsMySQL, '8.0.36', !If [ IsSQLServer, '14.00.3480.1.v1', '14.14-R1' ] ]
-      Engine: !If [ IsMySQL, 'mysql', !If [ IsSQLServer, 'sqlserver-se', 'postgres' ] ]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
-      LicenseModel: !If [ IsMySQL, 'general-public-license', !If [ IsSQLServer, 'license-included', 'postgresql-license' ] ]
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
       Iops: !Ref DBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISSessionDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -312,17 +292,17 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_SESSION ]
-      EngineVersion: !If [IsMySQL, '8.0.36', !If [IsSQLServer, '14.00.3480.1.v1', '14.14-R1']]
-      Engine: !If [IsMySQL, 'mysql', !If [IsSQLServer, 'sqlserver-se', 'postgres']]
-      EnablePerformanceInsights : 'false'
-      LicenseModel: !If [IsMySQL, 'general-public-license', !If [IsSQLServer, 'license-included', 'postgresql-license']]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
+      EnablePerformanceInsights: 'false'
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
       Iops: !Ref SessionDBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISDBSubnetGroupsuffix:
     Type: 'AWS::RDS::DBSubnetGroup'
@@ -683,10 +663,6 @@ Parameters:
     Description: >-
       The private key used to log in to instances through SSH
     Type: 'AWS::EC2::KeyPair::KeyName'
-  CertificateName:
-    Description: A valid SSL certificate used for HTTPS
-    Type: String
-    MinLength: 1
   WSO2InstanceType:
     Type: String
     Default: c6i.xlarge
@@ -709,9 +685,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  DBEngine:
-    Type: String
-    Default: MySQL_8.0
   DBPassword:
     Type: String
     MinLength: 8
@@ -751,9 +724,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  SessionDBEngine:
-    Type: String
-    Default: MySQL_8.0
   SessionDBPassword:
     Type: String
     MinLength: 8
@@ -787,22 +757,10 @@ Parameters:
     Description: Provide IOps size in numbers
     Type: Number
     Default: 1000
-  JDKVersion:
-    Type: String
-    Default: Oracle_JDK_8
-    AllowedValues:
-      - Open_JDK_8
-      - Oracle_JDK_8
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
     Default: user@wso2.com
-  OSType:
-    Type: String
-    Default: Ubuntu_18.04
-    AllowedValues:
-      - Ubuntu_18.04
-      - CentOS_7
   BastionInstanceType:
     Type: String
     Default: c6i.xlarge
@@ -832,6 +790,28 @@ Mappings:
       AMI: ami-0e81aa4c57820bb57
     us-west-2:
       AMI: ami-03fa1f014b48fa6bd
-Conditions:
-  IsMySQL: !Equals [!Ref DBType, mysql]
-  IsSQLServer: !Equals [!Ref DBType, mssql]
+  DBTypeMap:
+    mysql:
+      Version: '8.0.36'
+      License: 'general-public-license'
+      ParameterGroup: 'perf-test-param-group'
+      FromPort: '3306'
+      ToPort: '3306'
+      DBType: 'mysql'
+      DBName: 'WSO2_IS_DB_2'
+    mssql:
+      Version: '14.00.3480.1.v1'
+      License: 'license-included'
+      ParameterGroup: 'perf-test-param-group-sqlserver'
+      FromPort: '1433'
+      ToPort: '1433'
+      DBType: 'sqlserver-se'
+      DBName: !Ref "AWS::NoValue"
+    postgres:
+      Version: '14.14-R1'
+      License: 'postgresql-license'
+      ParameterGroup: 'perf-test-param-group-postgres'
+      FromPort: '5432'
+      ToPort: '5432'
+      DBType: 'postgres'
+      DBName: 'WSO2_IS_DB_2'

--- a/single-node/single-node.yaml
+++ b/single-node/single-node.yaml
@@ -24,17 +24,11 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
-          - OSType
-      - Label:
-          default: Network Configuration
-        Parameters:
-          - CertificateName
       - Label:
           default: Database Credentials
         Parameters:
           - DBUsername
           - DBPassword
-          - DBEngine
           - DBInstanceType
           - DBAllocationStorage
           - DBIops
@@ -44,18 +38,14 @@ Metadata:
         Parameters:
           - SessionDBUsername
           - SessionDBPassword
-          - SessionDBEngine
           - SessionDBInstanceType
           - SessionDBAllocationStorage
           - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
-          - JDK
           - UserTag
     ParameterLabels:
-      CertificateName:
-        default: SSL Certificate Name
       KeyPairName:
         default: Key Pair Name
       DBUsername:
@@ -66,14 +56,10 @@ Metadata:
         default: Username
       SessionDBPassword:
         default: Password
-      JDK:
-        default: JDK Version
       UserTag:
         default: User Tag
       WSO2InstanceType:
         default: Instance Type
-      DBEngine:
-        default: DB Engine
       DBAllocationStorage:
         default: Allocation Storage
       DBIops:
@@ -82,18 +68,12 @@ Metadata:
         default: DB Instance Type
       DBType:
         default: DB Type
-      SessionDBEngine:
-        default: Session DB Engine
       SessionDBAllocationStorage:
         default: Session DB Allocation Storage
       SessionDBIops:
         default: Session DB Allocation IOPS
       SessionDBInstanceType:
         default: Session DB Instance Type
-      JDKVersion:
-        default: JDK Version
-      OSType:
-        default: OS Type
       BastionInstanceType:
         default: Bastion Instance Type
 Resources:
@@ -212,8 +192,8 @@ Resources:
       GroupDescription: DB Security Group2
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISSessionDBInstanceSecurityGroupsuffix:
     Type: 'AWS::EC2::SecurityGroup'
@@ -222,8 +202,8 @@ Resources:
       GroupDescription: Session DB Security Group
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -235,17 +215,17 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_2 ]
-      EngineVersion: !If [ IsMySQL, '8.0.36', !If [ IsSQLServer, '14.00.3480.1.v1', '14.14-R1' ] ]
-      Engine: !If [ IsMySQL, 'mysql', !If [ IsSQLServer, 'sqlserver-se', 'postgres' ] ]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
-      LicenseModel: !If [ IsMySQL, 'general-public-license', !If [ IsSQLServer, 'license-included', 'postgresql-license' ] ]
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
       Iops: !Ref DBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISSessionDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -257,17 +237,17 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_SESSION ]
-      EngineVersion: !If [ IsMySQL, '8.0.36', !If [ IsSQLServer, '14.00.3480.1.v1', '14.14-R1' ] ]
-      Engine: !If [ IsMySQL, 'mysql', !If [ IsSQLServer, 'sqlserver-se', 'postgres' ] ]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
-      LicenseModel: !If [ IsMySQL, 'general-public-license', !If [ IsSQLServer, 'license-included', 'postgresql-license' ] ]
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
       Iops: !Ref SessionDBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres' ] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISDBSubnetGroupsuffix:
     Type: 'AWS::RDS::DBSubnetGroup'
@@ -495,10 +475,6 @@ Parameters:
     Description: >-
       The private key used to log in to instances through SSH
     Type: 'AWS::EC2::KeyPair::KeyName'
-  CertificateName:
-    Description: A valid SSL certificate used for HTTPS
-    Type: String
-    MinLength: 1
   WSO2InstanceType:
     Type: String
     Default: c6i.xlarge
@@ -521,9 +497,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  DBEngine:
-    Type: String
-    Default: MySQL_8.0
   DBPassword:
     Type: String
     MinLength: 8
@@ -563,9 +536,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  SessionDBEngine:
-    Type: String
-    Default: MySQL_8.0
   SessionDBPassword:
     Type: String
     MinLength: 8
@@ -599,22 +569,10 @@ Parameters:
     Description: Provide IOps size in numbers
     Type: Number
     Default: 1000
-  JDKVersion:
-    Type: String
-    Default: Oracle_JDK_8
-    AllowedValues:
-      - Open_JDK_8
-      - Oracle_JDK_8
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
     Default: user@wso2.com
-  OSType:
-    Type: String
-    Default: Ubuntu_18.04
-    AllowedValues:
-      - Ubuntu_18.04
-      - CentOS_7
   BastionInstanceType:
     Type: String
     Default: c6i.xlarge
@@ -644,6 +602,28 @@ Mappings:
       AMI: ami-0e81aa4c57820bb57
     us-west-2:
       AMI: ami-03fa1f014b48fa6bd
-Conditions:
-  IsMySQL: !Equals [!Ref DBType, mysql]
-  IsSQLServer: !Equals [!Ref DBType, mssql]
+  DBTypeMap:
+    mysql:
+      Version: '8.0.36'
+      License: 'general-public-license'
+      ParameterGroup: 'perf-test-param-group'
+      FromPort: '3306'
+      ToPort: '3306'
+      DBType: 'mysql'
+      DBName: 'WSO2_IS_DB_2'
+    mssql:
+      Version: '14.00.3480.1.v1'
+      License: 'license-included'
+      ParameterGroup: 'perf-test-param-group-sqlserver'
+      FromPort: '1433'
+      ToPort: '1433'
+      DBType: 'sqlserver-se'
+      DBName: !Ref "AWS::NoValue"
+    postgres:
+      Version: '14.14-R1'
+      License: 'postgresql-license'
+      ParameterGroup: 'perf-test-param-group-postgres'
+      FromPort: '5432'
+      ToPort: '5432'
+      DBType: 'postgres'
+      DBName: 'WSO2_IS_DB_2'

--- a/three-node-cluster/3-node-cluster.yml
+++ b/three-node-cluster/3-node-cluster.yml
@@ -27,17 +27,11 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
-          - OSType
-      - Label:
-          default: Network Configuration
-        Parameters:
-          - CertificateName
       - Label:
           default: Database Credentials
         Parameters:
           - DBUsername
           - DBPassword
-          - DBEngine
           - DBInstanceType
           - DBAllocationStorage
           - DBIops
@@ -47,18 +41,14 @@ Metadata:
         Parameters:
           - SessionDBUsername
           - SessionDBPassword
-          - SessionDBEngine
           - SessionDBInstanceType
           - SessionDBAllocationStorage
           - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
-          - JDK
           - UserTag
     ParameterLabels:
-      CertificateName:
-        default: SSL Certificate Name
       KeyPairName:
         default: Key Pair Name
       DBUsername:
@@ -69,14 +59,10 @@ Metadata:
         default: Username
       SessionDBPassword:
         default: Password
-      JDK:
-        default: JDK Version
       UserTag:
         default: User Tag
       WSO2InstanceType:
         default: Instance Type
-      DBEngine:
-        default: DB Engine
       DBAllocationStorage:
         default: Allocation Storage
       DBIops:
@@ -85,18 +71,12 @@ Metadata:
         default: DB Instance Type
       DBType:
         default: DB Type
-      SessionDBEngine:
-        default: Session DB Engine
       SessionDBAllocationStorage:
         default: Session DB Allocation Storage
       SessionDBIops:
         default: Session DB Allocation IOPS
       SessionDBInstanceType:
         default: Session DB Instance Type
-      JDKVersion:
-        default: JDK Version
-      OSType:
-        default: OS Type
       BastionInstanceType:
         default: Bastion Instance Type
 Resources:
@@ -241,8 +221,8 @@ Resources:
       GroupDescription: DB Security Group2
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISSessionDBInstanceSecurityGroupsuffix:
     Type: 'AWS::EC2::SecurityGroup'
@@ -251,8 +231,8 @@ Resources:
       GroupDescription: Session DB Security Group
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -264,17 +244,17 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_2 ]
-      EngineVersion: !If [ IsMySQL, '8.0.36', !If [ IsSQLServer, '14.00.3480.1.v1', '14.14-R1' ] ]
-      Engine: !If [ IsMySQL, 'mysql', !If [ IsSQLServer, 'sqlserver-se', 'postgres' ] ]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
-      LicenseModel: !If [ IsMySQL, 'general-public-license', !If [ IsSQLServer, 'license-included', 'postgresql-license' ] ]
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
       Iops: !Ref DBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISSessionDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -286,17 +266,17 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_SESSION ]
-      EngineVersion: !If [IsMySQL, '8.0.36', !If [IsSQLServer, '14.00.3480.1.v1', '14.14-R1']]
-      Engine: !If [IsMySQL, 'mysql', !If [IsSQLServer, 'sqlserver-se', 'postgres']]
-      EnablePerformanceInsights : 'false'
-      LicenseModel: !If [IsMySQL, 'general-public-license', !If [IsSQLServer, 'license-included', 'postgresql-license']]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
+      EnablePerformanceInsights: 'false'
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
       Iops: !Ref SessionDBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISDBSubnetGroupsuffix:
     Type: 'AWS::RDS::DBSubnetGroup'
@@ -313,10 +293,10 @@ Resources:
       VpcId: !Ref WSO2ISVPCsuffix
       GroupDescription: EFS Security Group
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: '2049'
-        ToPort: '2049'
-        CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: '2049'
+          ToPort: '2049'
+          CidrIp: 0.0.0.0/0
   WSO2ISEFSFileSystemsuffix:
     Type: 'AWS::EFS::FileSystem'
     Properties:
@@ -625,10 +605,6 @@ Parameters:
     Description: >-
       The private key used to log in to instances through SSH
     Type: 'AWS::EC2::KeyPair::KeyName'
-  CertificateName:
-    Description: A valid SSL certificate used for HTTPS
-    Type: String
-    MinLength: 1
   WSO2InstanceType:
     Type: String
     Default: c6i.xlarge
@@ -651,9 +627,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  DBEngine:
-    Type: String
-    Default: MySQL_8.0
   DBPassword:
     Type: String
     MinLength: 8
@@ -693,9 +666,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  SessionDBEngine:
-    Type: String
-    Default: MySQL_8.0
   SessionDBPassword:
     Type: String
     MinLength: 8
@@ -729,22 +699,10 @@ Parameters:
     Description: Provide IOps size in numbers
     Type: Number
     Default: 1000
-  JDKVersion:
-    Type: String
-    Default: Oracle_JDK_8
-    AllowedValues:
-      - Open_JDK_8
-      - Oracle_JDK_8
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
     Default: user@wso2.com
-  OSType:
-    Type: String
-    Default: Ubuntu_18.04
-    AllowedValues:
-      - Ubuntu_18.04
-      - CentOS_7
   BastionInstanceType:
     Type: String
     Default: c6i.xlarge
@@ -774,6 +732,28 @@ Mappings:
       AMI: ami-0e81aa4c57820bb57
     us-west-2:
       AMI: ami-03fa1f014b48fa6bd
-Conditions:
-  IsMySQL: !Equals [!Ref DBType, mysql]
-  IsSQLServer: !Equals [!Ref DBType, mssql]
+  DBTypeMap:
+    mysql:
+      Version: '8.0.36'
+      License: 'general-public-license'
+      ParameterGroup: 'perf-test-param-group'
+      FromPort: '3306'
+      ToPort: '3306'
+      DBType: 'mysql'
+      DBName: 'WSO2_IS_DB_2'
+    mssql:
+      Version: '14.00.3480.1.v1'
+      License: 'license-included'
+      ParameterGroup: 'perf-test-param-group-sqlserver'
+      FromPort: '1433'
+      ToPort: '1433'
+      DBType: 'sqlserver-se'
+      DBName: !Ref "AWS::NoValue"
+    postgres:
+      Version: '14.14-R1'
+      License: 'postgresql-license'
+      ParameterGroup: 'perf-test-param-group-postgres'
+      FromPort: '5432'
+      ToPort: '5432'
+      DBType: 'postgres'
+      DBName: 'WSO2_IS_DB_2'

--- a/two-node-cluster/2-node-cluster.yml
+++ b/two-node-cluster/2-node-cluster.yml
@@ -26,17 +26,11 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
-          - OSType
-      - Label:
-          default: Network Configuration
-        Parameters:
-          - CertificateName
       - Label:
           default: Database Credentials
         Parameters:
           - DBUsername
           - DBPassword
-          - DBEngine
           - DBInstanceType
           - DBAllocationStorage
           - DBIops
@@ -46,18 +40,14 @@ Metadata:
         Parameters:
           - SessionDBUsername
           - SessionDBPassword
-          - SessionDBEngine
           - SessionDBInstanceType
           - SessionDBAllocationStorage
           - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
-          - JDK
           - UserTag
     ParameterLabels:
-      CertificateName:
-        default: SSL Certificate Name
       KeyPairName:
         default: Key Pair Name
       DBUsername:
@@ -68,14 +58,10 @@ Metadata:
         default: Username
       SessionDBPassword:
         default: Password
-      JDK:
-        default: JDK Version
       UserTag:
         default: User Tag
       WSO2InstanceType:
         default: Instance Type
-      DBEngine:
-        default: DB Engine
       DBAllocationStorage:
         default: Allocation Storage
       DBIops:
@@ -84,18 +70,12 @@ Metadata:
         default: DB Instance Type
       DBType:
         default: DB Type
-      SessionDBEngine:
-        default: Session DB Engine
       SessionDBAllocationStorage:
         default: Session DB Allocation Storage
       SessionDBIops:
         default: Session DB Allocation IOPS
       SessionDBInstanceType:
         default: Session DB Instance Type
-      JDKVersion:
-        default: JDK Version
-      OSType:
-        default: OS Type
       BastionInstanceType:
         default: Bastion Instance Type
 Resources:
@@ -214,8 +194,8 @@ Resources:
       GroupDescription: DB Security Group2
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISSessionDBInstanceSecurityGroupsuffix:
     Type: 'AWS::EC2::SecurityGroup'
@@ -224,8 +204,8 @@ Resources:
       GroupDescription: Session DB Security Group
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
-          ToPort: !If [ IsMySQL, '3306', !If [ IsSQLServer, '1433', '5432' ] ]
+          FromPort: !FindInMap [DBTypeMap, !Ref DBType, FromPort]
+          ToPort: !FindInMap [DBTypeMap, !Ref DBType, ToPort]
           CidrIp: 0.0.0.0/0
   WSO2ISDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -237,17 +217,17 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_2 ]
-      EngineVersion: !If [ IsMySQL, '8.0.36', !If [ IsSQLServer, '14.00.3480.1.v1', '14.14-R1' ] ]
-      Engine: !If [ IsMySQL, 'mysql', !If [ IsSQLServer, 'sqlserver-se', 'postgres' ] ]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
-      LicenseModel: !If [ IsMySQL, 'general-public-license', !If [ IsSQLServer, 'license-included', 'postgresql-license' ] ]
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
       Iops: !Ref DBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISSessionDBInstancesuffix:
     Type: 'AWS::RDS::DBInstance'
@@ -259,17 +239,17 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !If [ IsSQLServer, !Ref "AWS::NoValue", WSO2_IS_DB_SESSION ]
-      EngineVersion: !If [IsMySQL, '8.0.36', !If [IsSQLServer, '14.00.3480.1.v1', '14.14-R1']]
-      Engine: !If [IsMySQL, 'mysql', !If [IsSQLServer, 'sqlserver-se', 'postgres']]
-      EnablePerformanceInsights : 'false'
-      LicenseModel: !If [IsMySQL, 'general-public-license', !If [IsSQLServer, 'license-included', 'postgresql-license']]
+      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
+      Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
+      EnablePerformanceInsights: 'false'
+      LicenseModel: !FindInMap [DBTypeMap, !Ref DBType, License]
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
       Iops: !Ref SessionDBIops
       StorageType: io1
-      DBParameterGroupName: !If [ IsMySQL, 'perf-test-param-group', !If [ IsSQLServer, 'perf-test-param-group-sqlserver', 'perf-test-param-group-postgres'] ]
+      DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
   WSO2ISDBSubnetGroupsuffix:
     Type: 'AWS::RDS::DBSubnetGroup'
@@ -566,10 +546,6 @@ Parameters:
     Description: >-
       The private key used to log in to instances through SSH
     Type: 'AWS::EC2::KeyPair::KeyName'
-  CertificateName:
-    Description: A valid SSL certificate used for HTTPS
-    Type: String
-    MinLength: 1
   WSO2InstanceType:
     Type: String
     Default: c6i.xlarge
@@ -592,9 +568,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  DBEngine:
-    Type: String
-    Default: MySQL_8.0
   DBPassword:
     Type: String
     MinLength: 8
@@ -634,9 +607,6 @@ Parameters:
     Type: String
     MinLength: 4
     AllowedPattern: '[A-Za-z0-9\-]+'
-  SessionDBEngine:
-    Type: String
-    Default: MySQL_8.0
   SessionDBPassword:
     Type: String
     MinLength: 8
@@ -670,22 +640,10 @@ Parameters:
     Description: Provide IOps size in numbers
     Type: Number
     Default: 1000
-  JDKVersion:
-    Type: String
-    Default: Oracle_JDK_8
-    AllowedValues:
-      - Open_JDK_8
-      - Oracle_JDK_8
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
     Default: user@wso2.com
-  OSType:
-    Type: String
-    Default: Ubuntu_18.04
-    AllowedValues:
-      - Ubuntu_18.04
-      - CentOS_7
   BastionInstanceType:
     Type: String
     Default: c6i.xlarge
@@ -715,6 +673,28 @@ Mappings:
       AMI: ami-0e81aa4c57820bb57
     us-west-2:
       AMI: ami-03fa1f014b48fa6bd
-Conditions:
-  IsMySQL: !Equals [!Ref DBType, mysql]
-  IsSQLServer: !Equals [!Ref DBType, mssql]
+  DBTypeMap:
+    mysql:
+      Version: '8.0.36'
+      License: 'general-public-license'
+      ParameterGroup: 'perf-test-param-group'
+      FromPort: '3306'
+      ToPort: '3306'
+      DBType: 'mysql'
+      DBName: 'WSO2_IS_DB_2'
+    mssql:
+      Version: '14.00.3480.1.v1'
+      License: 'license-included'
+      ParameterGroup: 'perf-test-param-group-sqlserver'
+      FromPort: '1433'
+      ToPort: '1433'
+      DBType: 'sqlserver-se'
+      DBName: !Ref "AWS::NoValue"
+    postgres:
+      Version: '14.14-R1'
+      License: 'postgresql-license'
+      ParameterGroup: 'perf-test-param-group-postgres'
+      FromPort: '5432'
+      ToPort: '5432'
+      DBType: 'postgres'
+      DBName: 'WSO2_IS_DB_2'


### PR DESCRIPTION
## Summary
This pull request includes significant changes to the configuration and setup files for performance testing and AWS CloudFormation templates. The primary focus is on removing the dependency on specific IAM certificates and simplifying the database configuration by using a mapping for database types.

### Configuration Changes:

* Removed `certificate_name` parameter and its associated usage from `common/start-performance.sh` 

### CloudFormation Template Changes:

 * Removed parameters and labels related to `CertificateName`, `DBEngine`, `SessionDBEngine`, `JDKVersion`, and `OSType` 
 * Simplified security group configuration by using `DBTypeMap` for port mappings 
 * Updated database instance configurations to use `DBTypeMap` for properties like `DBName`, `EngineVersion`, `Engine`, `LicenseModel`, and `DBParameterGroupName` 
 
## Related Issue
https://github.com/wso2/product-is/issues/21509
