### PR TITLE
Add a config to enable using DB snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See usage:
 ./start-performance.sh -k <key_file>
    -c <certificate_name> -j <jmeter_setup_path>
    [-n <IS_zip_file_path>]
-   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <use_db_snapshot>]
+   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>]
    [-i <wso2_is_instance_type>] [-b <bastion_instance_type>] [-t <keystore_type>] [-m <db_type>]
    [-l <is_case_insensitive_username_and_attributes>]
    [-w <minimum_stack_creation_wait_time>] [-h]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See usage:
 -n: The is server zip
 -u: The database username. Default: wso2carbon.
 -p: The database password. Default: wso2carbon.
--s: Use existing snapshot for the database.
+-s: The database snapshot ID. Default: -.
 -e: The database instance type. Default: db.m6i.2xlarge.
 -i: The instance type used for IS nodes. Default: c6i.xlarge.
 -b: The instance type used for the bastion node. Default: c6i.xlarge.

--- a/README.md
+++ b/README.md
@@ -63,25 +63,33 @@ mvn clean install
 See usage:
 
 ```console
-./start-performance.sh -k <key_file> -a <aws_access_key> -s <aws_access_secret>
+./start-performance.sh -k <key_file>
    -c <certificate_name> -j <jmeter_setup_path>
    [-n <IS_zip_file_path>]
-   [-u <db_username>] [-p <db_password>]
-   [-i <wso2_is_instance_type>] [-b <bastion_instance_type>]
+   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <use_db_snapshot>]
+   [-i <wso2_is_instance_type>] [-b <bastion_instance_type>] [-t <keystore_type>] [-m <db_type>]
+   [-l <is_case_insensitive_username_and_attributes>]
    [-w <minimum_stack_creation_wait_time>] [-h]
 
 -k: The Amazon EC2 key file to be used to access the instances.
--a: The AWS access key.
--s: The AWS access secret.
+-c: The name of the IAM certificate.
+-y: The token issuer type.
+-q: User tag who triggered the Jenkins build
 -j: The path to JMeter setup.
 -c: The name of the IAM certificate.
 -n: The is server zip
 -u: The database username. Default: wso2carbon.
 -p: The database password. Default: wso2carbon.
+-s: Use existing snapshot for the database.
+-e: The database instance type. Default: db.m6i.2xlarge.
 -i: The instance type used for IS nodes. Default: c6i.xlarge.
 -b: The instance type used for the bastion node. Default: c6i.xlarge.
 -w: The minimum time to wait in minutes before polling for cloudformation stack's CREATE_COMPLETE status.
     Default: 10 minutes.
+-g: Number of IS nodes.
+-t: Keystore type. Default: PKCS12.
+-m: Database type. Default: mysql.
+-l: Case insensitivity of the username and attributes. Default: false.
 -h: Display this help and exit.
 ```
 

--- a/common/deployment/setup/resources/mysql/create_database_from_snapshot.sql
+++ b/common/deployment/setup/resources/mysql/create_database_from_snapshot.sql
@@ -1,0 +1,6 @@
+drop database if exists IDENTITY_DB;
+
+create database IDENTITY_DB;
+
+use IDENTITY_DB; source ~/wso2is/dbscripts/identity/mysql.sql;
+use IDENTITY_DB; source ~/wso2is/dbscripts/consent/mysql.sql;

--- a/common/jmeter/perf-test-is.sh
+++ b/common/jmeter/perf-test-is.sh
@@ -448,24 +448,31 @@ function print_durations() {
     printf "Script execution time: %s\n" "$(format_time $(measure_time "$test_start_time"))"
 }
 
-function run_b2b_test_data_scripts() {
+function run_jmeter_scripts() {
 
-    echo "Running b2b test data setup scripts"
-    echo "=========================================================================================="
-    declare -a scripts=("TestData_Add_Sub_Orgs.jmx" "TestData_Add_B2B_OAuth_Apps.jmx" "TestData_SCIM2_Add_Sub_Org_Users.jmx")
-    setup_dir="/home/ubuntu/workspace/jmeter/setup"
+    local scripts=("$@")
+    local setup_dir="/home/ubuntu/workspace/jmeter/setup"
+    local additional_params="$additional_jmeter_params"
 
     for script in "${scripts[@]}"; do
         script_file="$setup_dir/$script"
         test_data_store="test-data/$script"
-        mkdir -p $test_data_store
-        command="jmeter -Jhost=$lb_host -Jport=$is_port -JtokenIssuer=$token_issuer -JnoOfNodes=$noOfNodes -n -t $script_file"
-        command+=" -l test_data_store/results.jtl"
+        mkdir -p "$test_data_store"
+        command="jmeter -Jhost=$lb_host -Jport=$is_port -JtokenIssuer=$token_issuer -JnoOfNodes=$noOfNodes $additional_params -n -t $script_file"
+        command+=" -JuserCount=$userCount -l test_data_store/results.jtl"
         echo "$command"
         echo ""
         $command
         echo ""
     done
+}
+
+function run_b2b_test_data_scripts() {
+
+    echo "Running b2b test data setup scripts"
+    echo "=========================================================================================="
+    declare -a scripts=("TestData_Add_Sub_Orgs.jmx" "TestData_Add_B2B_OAuth_Apps.jmx" "TestData_SCIM2_Add_Sub_Org_Users.jmx")
+    run_jmeter_scripts "${scripts[@]}"
 }
 
 function run_test_data_scripts() {
@@ -473,17 +480,8 @@ function run_test_data_scripts() {
     echo "Running test data setup scripts"
     echo "=========================================================================================="
     declare -a scripts=("TestData_SCIM2_Add_User.jmx" "TestData_Add_OAuth_Apps.jmx" "TestData_Add_OAuth_Apps_Requesting_Claims.jmx" "TestData_Add_OAuth_Apps_Without_Consent.jmx" "TestData_Add_SAML_Apps.jmx" "TestData_Add_Device_Flow_OAuth_Apps.jmx" "TestData_Add_OAuth_Idps.jmx" "TestData_Get_OAuth_Jwt_Token.jmx")
-#    declare -a scripts=("TestData_Add_Super_Tenant_Users.jmx" "TestData_Add_OAuth_Apps.jmx" "TestData_Add_SAML_Apps.jmx" "TestData_Add_Tenants.jmx" "TestData_Add_Tenant_Users.jmx")
-    setup_dir="/home/ubuntu/workspace/jmeter/setup"
-
-    for script in "${scripts[@]}"; do
-        script_file="$setup_dir/$script"
-        command="jmeter -Jhost=$lb_host -Jport=$is_port -JtokenIssuer=$token_issuer -JjwtTokenUserPassword=$jwt_token_user_password -JjwtTokenClientSecret=$jwt_token_client_secret -JnoOfNodes=$noOfNodes -n -t $script_file"
-        echo "$command"
-        echo ""
-        $command
-        echo ""
-    done
+    additional_jmeter_params="-JjwtTokenUserPassword=$jwt_token_user_password -JjwtTokenClientSecret=$jwt_token_client_secret"
+    run_jmeter_scripts "${scripts[@]}"
 }
 
 function run_tenant_test_data_scripts() {
@@ -491,16 +489,8 @@ function run_tenant_test_data_scripts() {
     echo "Running tenant test data setup scripts"
     echo "=========================================================================================="
     declare -a scripts=( "TestData_Add_Tenants.jmx" "TestData_SCIM2_Add_Tenant_Users.jmx" "TestData_Add_Tenant_OAuth_Apps.jmx" "TestData_Add_Tenant_SAML_Apps.jmx" "TestData_Add_Tenant_Device_Flow_OAuth_Apps.jmx" "TestData_Add_Tenant_OAuth_Idps.jmx" "TestData_Get_OAuth_Jwt_Token.jmx")
-    setup_dir="/home/ubuntu/workspace/jmeter/setup"
-
-    for script in "${scripts[@]}"; do
-        script_file="$setup_dir/$script"
-        command="jmeter -Jhost=$lb_host -Jport=$is_port -JtokenIssuer=$token_issuer -JnoOfTenants=$noOfTenants -JspCount=$spCount -JidpCount=$idpCount -JuserCount=$userCount -JjwtTokenUserPassword=$jwt_token_user_password -JjwtTokenClientSecret=$jwt_token_client_secret -JnoOfNodes=$noOfNodes -n -t $script_file"
-        echo "$command"
-        echo ""
-        $command
-        echo ""
-    done
+    additional_jmeter_params="-JnoOfTenants=$noOfTenants -JspCount=$spCount -JidpCount=$idpCount -JjwtTokenUserPassword=$jwt_token_user_password -JjwtTokenClientSecret=$jwt_token_client_secret"
+    run_jmeter_scripts "${scripts[@]}"
 }
 
 function initiailize_test() {
@@ -644,11 +634,11 @@ function test_scenarios() {
                 mkdir -p "$report_location"
 
                 time=$(expr "$test_duration" \* 60)
-                declare -ag jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "-Jport=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment")
+                declare -ag jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "-Jport=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "-JuserCount=$userCount")
 
                 local tenantMode=${scenario[tenantMode]}
                 if [ "$tenantMode" = true ]; then
-                      jmeter_params+=" -JtenantMode=true -JnoOfTenants=$noOfTenants -JspCount=$spCount -JidpCount=$idpCount -JuserCount=$userCount"
+                      jmeter_params+=" -JtenantMode=true -JnoOfTenants=$noOfTenants -JspCount=$spCount -JidpCount=$idpCount"
                 fi
 
                 before_execute_test_scenario "$db_type"

--- a/common/jmeter/setup/TestData_SCIM2_Add_User.jmx
+++ b/common/jmeter/setup/TestData_SCIM2_Add_User.jmx
@@ -76,17 +76,17 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="noOfThreads" elementType="Argument">
             <stringProp name="Argument.name">noOfThreads</stringProp>
-            <stringProp name="Argument.value">${__P(concurrency,1)}</stringProp>
+            <stringProp name="Argument.value">${__P(concurrency,20)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="noOfUsers" elementType="Argument">
             <stringProp name="Argument.name">noOfUsers</stringProp>
-            <stringProp name="Argument.value">${__P(userCount,10)}</stringProp>
+            <stringProp name="Argument.value">${__P(userCount,1000)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="loopCount" elementType="Argument">
             <stringProp name="Argument.name">loopCount</stringProp>
-            <stringProp name="Argument.value">${__P(loopCount,1000)}</stringProp>
+            <stringProp name="Argument.value">${__jexl3(${__P(userCount,1000)}/${__P(concurrency,20)})}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="rampUpPeriod" elementType="Argument">

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -180,11 +180,12 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-if [[ $db_snapshot_id == "-" ]]; then
+# TODO: add snapshot support for other db types
+if [[ $db_snapshot_id != "-" && $db_type == "mysql" ]]; then
+    use_db_snapshot="true"
+else
     db_snapshot_id=""
     use_db_snapshot="false"
-else
-    use_db_snapshot="true"
 fi
 
 # Pass the modified options to the command
@@ -463,11 +464,13 @@ if [[ $no_of_nodes -gt 3 ]]; then
     sleep 5m
 fi
 
-if [[ $use_db_snapshot == "false" ]]; then
-    echo ""
-    echo "Creating databases in RDS..."
-    echo "============================================"
-    ssh_bastion_cmd "cd /home/ubuntu/ ; unzip -q wso2is.zip ; mv wso2is-* wso2is"
+echo ""
+echo "Creating databases in RDS..."
+echo "============================================"
+ssh_bastion_cmd "cd /home/ubuntu/ ; unzip -q wso2is.zip ; mv wso2is-* wso2is"
+if [[ $use_db_snapshot == "true" ]]; then
+    execute_db_command "$rds_host" "/home/ubuntu/workspace/setup/resources/mysql/create_database_from_snapshot.sql"
+else
     execute_db_command "$rds_host" "/home/ubuntu/workspace/setup/resources/$db_type/create_database.sql"
 fi
 

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -39,7 +39,7 @@ bastion_instance_type="$default_bastion_instance_type"
 keystore_type="JKS"
 db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
-use_db_snapshot="false"
+use_db_snapshot="true"
 db_snapshot_identifier=""
 
 results_dir="$PWD/results-$timestamp"

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -40,7 +40,7 @@ keystore_type="JKS"
 db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
 use_db_snapshot="false"
-db_snapshot_id="wso2isusersnapshot1m"
+db_snapshot_id=""
 
 results_dir="$PWD/results-$timestamp"
 default_minimum_stack_creation_wait_time=10

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -461,11 +461,13 @@ if [[ $no_of_nodes -gt 3 ]]; then
     sleep 5m
 fi
 
-echo ""
-echo "Creating databases in RDS..."
-echo "============================================"
-ssh_bastion_cmd "cd /home/ubuntu/ ; unzip -q wso2is.zip ; mv wso2is-* wso2is"
-execute_db_command "$rds_host" "/home/ubuntu/workspace/setup/resources/$db_type/create_database.sql"
+if [[ $use_db_snapshot != "true" ]]; then
+    echo ""
+    echo "Creating databases in RDS..."
+    echo "============================================"
+    ssh_bastion_cmd "cd /home/ubuntu/ ; unzip -q wso2is.zip ; mv wso2is-* wso2is"
+    execute_db_command "$rds_host" "/home/ubuntu/workspace/setup/resources/$db_type/create_database.sql"
+fi
 
 echo ""
 echo "Creating session database in RDS..."

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -40,7 +40,7 @@ keystore_type="JKS"
 db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
 use_db_snapshot="false"
-db_snapshot_id=""
+db_snapshot_id="wso2isusersnapshot1m"
 
 results_dir="$PWD/results-$timestamp"
 default_minimum_stack_creation_wait_time=10

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -39,7 +39,7 @@ bastion_instance_type="$default_bastion_instance_type"
 keystore_type="JKS"
 db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
-use_db_snapshot="true"
+use_db_snapshot="false"
 db_snapshot_id=""
 
 results_dir="$PWD/results-$timestamp"
@@ -183,6 +183,8 @@ done
 if [[ $db_snapshot_id == "-" ]]; then
     db_snapshot_id=""
     use_db_snapshot="false"
+else
+    use_db_snapshot="true"
 fi
 
 # Pass the modified options to the command

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -181,7 +181,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Pass the modified options to the command
-run_performance_tests_options=("-b ${db_type} -g ${no_of_nodes} -r ${modified_options[@]}")
+run_performance_tests_options=("-b ${db_type} -g ${no_of_nodes} -a ${use_db_snapshot} -r ${modified_options[@]}")
 
 if [[ -z $user_tag ]]; then
     echo "Please provide the user tag."

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -39,7 +39,7 @@ bastion_instance_type="$default_bastion_instance_type"
 keystore_type="JKS"
 db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
-use_db_snapshot="false"
+use_db_snapshot=false
 db_snapshot_id=""
 
 results_dir="$PWD/results-$timestamp"
@@ -182,10 +182,10 @@ done
 
 # TODO: add snapshot support for other db types
 if [[ $db_snapshot_id != "-" && $db_type == "mysql" ]]; then
-    use_db_snapshot="true"
+    use_db_snapshot=true
 else
     db_snapshot_id=""
-    use_db_snapshot="false"
+    use_db_snapshot=false
 fi
 
 # Pass the modified options to the command
@@ -468,7 +468,7 @@ echo ""
 echo "Creating databases in RDS..."
 echo "============================================"
 ssh_bastion_cmd "cd /home/ubuntu/ ; unzip -q wso2is.zip ; mv wso2is-* wso2is"
-if [[ $use_db_snapshot == "true" ]]; then
+if $use_db_snapshot; then
     execute_db_command "$rds_host" "/home/ubuntu/workspace/setup/resources/mysql/create_database_from_snapshot.sql"
 else
     execute_db_command "$rds_host" "/home/ubuntu/workspace/setup/resources/$db_type/create_database.sql"

--- a/four-node-cluster/4-node-cluster.yml
+++ b/four-node-cluster/4-node-cluster.yml
@@ -40,6 +40,7 @@ Metadata:
           - DBAllocationStorage
           - DBIops
           - DBType
+          - DBSnapshotId
       - Label:
           default: Session Database Credentials
         Parameters:
@@ -276,7 +277,7 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      DBSnapshotIdentifier: !Ref DBSnapshotId
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -298,7 +299,6 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -727,6 +727,10 @@ Parameters:
       - mssql
       - postgres
     Default: mysql
+  DBSnapshotId:
+    Description: Snapshot ID to restore the database from
+    Type: String
+    Default: ''
   DBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
@@ -767,7 +771,7 @@ Parameters:
   SessionDBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
-    Default: 50
+    Default: 100
   SessionDBIops:
     Description: Provide IOps size in numbers
     Type: Number
@@ -813,7 +817,6 @@ Mappings:
       FromPort: '3306'
       ToPort: '3306'
       DBType: 'mysql'
-      DBName: 'WSO2_IS_DB_2'
     mssql:
       Version: '14.00.3480.1.v1'
       License: 'license-included'
@@ -821,7 +824,6 @@ Mappings:
       FromPort: '1433'
       ToPort: '1433'
       DBType: 'sqlserver-se'
-      DBName: ''
     postgres:
       Version: '14.14'
       License: 'postgresql-license'
@@ -829,4 +831,3 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
-      DBName: 'WSO2_IS_DB_2'

--- a/four-node-cluster/run-performance-tests.sh
+++ b/four-node-cluster/run-performance-tests.sh
@@ -39,7 +39,6 @@ function before_execute_test_scenario() {
     ssh $wso2is_2_host_alias "./restart-is.sh -m $heap"
     ssh $wso2is_3_host_alias "./restart-is.sh -m $heap"
     ssh $wso2is_4_host_alias "./restart-is.sh -m $heap"
-    jmeter_params+=("port=443")
 
     echo "Cleaning databases..."
     rds_host=$(get_ssh_hostname $rds_ssh_host_alias)

--- a/single-node/single-node.yaml
+++ b/single-node/single-node.yaml
@@ -37,6 +37,7 @@ Metadata:
           - DBAllocationStorage
           - DBIops
           - DBType
+          - DBSnapshotId
       - Label:
           default: Session Database Credentials
         Parameters:
@@ -221,7 +222,7 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      DBSnapshotIdentifier: !Ref DBSnapshotId
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -243,7 +244,6 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -539,6 +539,10 @@ Parameters:
       - mssql
       - postgres
     Default: mysql
+  DBSnapshotId:
+    Description: Snapshot ID to restore the database from
+    Type: String
+    Default: ''
   DBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
@@ -579,7 +583,7 @@ Parameters:
   SessionDBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
-    Default: 50
+    Default: 100
   SessionDBIops:
     Description: Provide IOps size in numbers
     Type: Number
@@ -625,7 +629,6 @@ Mappings:
       FromPort: '3306'
       ToPort: '3306'
       DBType: 'mysql'
-      DBName: 'WSO2_IS_DB_2'
     mssql:
       Version: '14.00.3480.1.v1'
       License: 'license-included'
@@ -633,7 +636,6 @@ Mappings:
       FromPort: '1433'
       ToPort: '1433'
       DBType: 'sqlserver-se'
-      DBName: ''
     postgres:
       Version: '14.14'
       License: 'postgresql-license'
@@ -641,4 +643,3 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
-      DBName: 'WSO2_IS_DB_2'

--- a/three-node-cluster/3-node-cluster.yml
+++ b/three-node-cluster/3-node-cluster.yml
@@ -40,6 +40,7 @@ Metadata:
           - DBAllocationStorage
           - DBIops
           - DBType
+          - DBSnapshotId
       - Label:
           default: Session Database Credentials
         Parameters:
@@ -250,7 +251,7 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      DBSnapshotIdentifier: !Ref DBSnapshotId
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -272,7 +273,6 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -669,6 +669,10 @@ Parameters:
       - mssql
       - postgres
     Default: mysql
+  DBSnapshotId:
+    Description: Snapshot ID to restore the database from
+    Type: String
+    Default: ''
   DBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
@@ -709,7 +713,7 @@ Parameters:
   SessionDBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
-    Default: 50
+    Default: 100
   SessionDBIops:
     Description: Provide IOps size in numbers
     Type: Number
@@ -755,7 +759,6 @@ Mappings:
       FromPort: '3306'
       ToPort: '3306'
       DBType: 'mysql'
-      DBName: 'WSO2_IS_DB_2'
     mssql:
       Version: '14.00.3480.1.v1'
       License: 'license-included'
@@ -763,7 +766,6 @@ Mappings:
       FromPort: '1433'
       ToPort: '1433'
       DBType: 'sqlserver-se'
-      DBName: ''
     postgres:
       Version: '14.14'
       License: 'postgresql-license'
@@ -771,4 +773,3 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
-      DBName: 'WSO2_IS_DB_2'

--- a/three-node-cluster/run-performance-tests.sh
+++ b/three-node-cluster/run-performance-tests.sh
@@ -37,7 +37,6 @@ function before_execute_test_scenario() {
     ssh $wso2is_1_host_alias "./restart-is.sh -m $heap"
     ssh $wso2is_2_host_alias "./restart-is.sh -m $heap"
     ssh $wso2is_3_host_alias "./restart-is.sh -m $heap"
-    jmeter_params+=("port=443")
 
     echo "Cleaning databases..."
     rds_host=$(get_ssh_hostname $rds_ssh_host_alias)

--- a/two-node-cluster/2-node-cluster.yml
+++ b/two-node-cluster/2-node-cluster.yml
@@ -39,6 +39,7 @@ Metadata:
           - DBAllocationStorage
           - DBIops
           - DBType
+          - DBSnapshotId
       - Label:
           default: Session Database Credentials
         Parameters:
@@ -223,7 +224,7 @@ Resources:
       AllocatedStorage: !Ref DBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
+      DBSnapshotIdentifier: !Ref DBSnapshotId
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -245,7 +246,6 @@ Resources:
       AllocatedStorage: !Ref SessionDBAllocationStorage
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
-      DBName: !FindInMap [DBTypeMap, !Ref DBType, DBName]
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
       Engine: !FindInMap [DBTypeMap, !Ref DBType, DBType]
       EnablePerformanceInsights: 'false'
@@ -610,6 +610,10 @@ Parameters:
       - mssql
       - postgres
     Default: mysql
+  DBSnapshotId:
+    Description: Snapshot ID to restore the database from
+    Type: String
+    Default: ''
   DBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
@@ -650,7 +654,7 @@ Parameters:
   SessionDBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
-    Default: 50
+    Default: 100
   SessionDBIops:
     Description: Provide IOps size in numbers
     Type: Number
@@ -696,7 +700,6 @@ Mappings:
       FromPort: '3306'
       ToPort: '3306'
       DBType: 'mysql'
-      DBName: 'WSO2_IS_DB_2'
     mssql:
       Version: '14.00.3480.1.v1'
       License: 'license-included'
@@ -704,7 +707,6 @@ Mappings:
       FromPort: '1433'
       ToPort: '1433'
       DBType: 'sqlserver-se'
-      DBName: ''
     postgres:
       Version: '14.14'
       License: 'postgresql-license'
@@ -712,4 +714,3 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
-      DBName: 'WSO2_IS_DB_2'

--- a/two-node-cluster/run-performance-tests.sh
+++ b/two-node-cluster/run-performance-tests.sh
@@ -37,7 +37,6 @@ function before_execute_test_scenario() {
 
     ssh $wso2is_1_host_alias "./restart-is.sh -m $heap"
     ssh $wso2is_2_host_alias "./restart-is.sh -m $heap"
-    jmeter_params+=("port=443")
 
     echo "Cleaning databases..."
     rds_host=$(get_ssh_hostname $rds_ssh_host_alias)


### PR DESCRIPTION
This pull request includes several changes to enhance the performance testing setup and streamline database configuration. The key changes include updates to the `README.md` for new script parameters, modifications to database setup scripts, and improvements to the performance test scripts. 

### Documentation Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R92): Added new parameters for performance script usage, such as `-e` for database instance type, `-s` for using existing database snapshots, `-t` for keystore type, `-m` for database type, and `-l` for case insensitivity of usernames and attributes. Removed AWS access key and secret parameters.

### Database Setup:
* [`common/deployment/setup/resources/mysql/create_database_from_snapshot.sql`](diffhunk://#diff-dd01a8f049226a190dcb16670cb4cd099ca8456be894b8d81a40d15b960c5dc7R1-R6): Added script to drop and create the `IDENTITY_DB` database from a snapshot.

### Performance Test Scripts:
* `common/jmeter/perf-test-is.sh`: 
  - Introduced `use_db_snapshot` variable and added support for using database snapshots in the performance test script. [[1]](diffhunk://#diff-46c23810bc71e6d4b8636b9b69c19aa7ea34a842c99d8bb512538b1daddbddf4R91) [[2]](diffhunk://#diff-46c23810bc71e6d4b8636b9b69c19aa7ea34a842c99d8bb512538b1daddbddf4R218-R220)
  - Updated the `usage` function to include the new `-a` parameter for using existing database snapshots.
  - Refactored the script to use a helper function `run_jmeter_scripts` for running JMeter scripts with common parameters. [[1]](diffhunk://#diff-46c23810bc71e6d4b8636b9b69c19aa7ea34a842c99d8bb512538b1daddbddf4L451-R471) [[2]](diffhunk://#diff-46c23810bc71e6d4b8636b9b69c19aa7ea34a842c99d8bb512538b1daddbddf4R480-R513)
  - Added a new function `run_test_data_scripts_with_user_snapshot` for running test data setup scripts when using a database snapshot.

### CloudFormation Template:
* `four-node-cluster/4-node-cluster.yml`: 
  - Added `DBSnapshotId` parameter for restoring the database from a snapshot. [[1]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958R43) [[2]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958R730-R733)
  - Updated the database resources to use `DBSnapshotIdentifier` instead of `DBName` for snapshot restoration. [[1]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L279-R280) [[2]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L301)

### Miscellaneous:
* `common/start-performance.sh`: 
  - Added support for the new `-s` parameter to specify the database snapshot ID and updated the script to handle snapshot-based database creation. [[1]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL33-L36) [[2]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR42-R43) [[3]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL55-R53) [[4]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL70-R68) [[5]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL80-R78) [[6]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL105-R102) [[7]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL128-R126) [[8]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR183-R192) [[9]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL316-R325) [[10]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR471-R475)

### Related issue 
https://github.com/wso2/product-is/issues/21517