### PR TITLE
Enable high concurrency mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See usage:
 ./start-performance.sh -k <key_file>
    -c <certificate_name> -j <jmeter_setup_path>
    [-n <IS_zip_file_path>]
-   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>]
+   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>] [-r <concurrency>]
    [-i <wso2_is_instance_type>] [-b <bastion_instance_type>] [-t <keystore_type>] [-m <db_type>]
    [-l <is_case_insensitive_username_and_attributes>]
    [-w <minimum_stack_creation_wait_time>] [-h]
@@ -75,6 +75,7 @@ See usage:
 -c: The name of the IAM certificate.
 -y: The token issuer type.
 -q: User tag who triggered the Jenkins build
+-r: Concurrency (50-500, 500-3000, 50-3000)
 -j: The path to JMeter setup.
 -c: The name of the IAM certificate.
 -n: The is server zip

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -26,7 +26,7 @@ key_file=""
 certificate_name=""
 jmeter_setup=""
 is_setup=""
-concurrency_type=""
+concurrency=""
 default_db_username="wso2carbon"
 db_username="$default_db_username"
 default_db_password="wso2carbon"
@@ -52,7 +52,7 @@ function usage() {
     echo ""
     echo "Usage: "
     echo "$0 -k <key_file> -c <certificate_name> -j <jmeter_setup_path> -n <IS_zip_file_path>"
-    echo "   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>]"
+    echo "   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>] [-r <concurrency>]"
     echo "   [-i <wso2_is_instance_type>] [-b <bastion_instance_type>] [-t <keystore_type>] [-m <db_type>]"
     echo "   [-l <is_case_insensitive_username_and_attributes>]"
     echo "   [-w <minimum_stack_creation_wait_time>] [-h]"
@@ -61,7 +61,7 @@ function usage() {
     echo "-c: The name of the IAM certificate."
     echo "-y: The token issuer type."
     echo "-q: User tag who triggered the Jenkins build"
-    echo "-r: Concurrency type (50-500, 500-3000, 50-3000)"
+    echo "-r: Concurrency (50-500, 500-3000, 50-3000)"
     echo "-m: Enable burst traffic"
     echo "-j: The path to JMeter setup."
     echo "-n: The is server zip"
@@ -125,7 +125,7 @@ while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:r:h" opts; do
         db_password=${OPTARG}
         ;;
     r)
-        concurrency_type=${OPTARG}
+        concurrency=${OPTARG}
         ;;
     s)
         db_snapshot_id=${OPTARG}
@@ -194,7 +194,7 @@ else
 fi
 
 # Pass the modified options to the command
-run_performance_tests_options=("-b ${db_type} -g ${no_of_nodes} -a ${use_db_snapshot} -r ${concurrency_type} -v ${modified_options[@]}")
+run_performance_tests_options=("-b ${db_type} -g ${no_of_nodes} -a ${use_db_snapshot} -r ${concurrency} -v ${modified_options[@]}")
 
 if [[ -z $user_tag ]]; then
     echo "Please provide the user tag."
@@ -245,7 +245,7 @@ else
 fi
 
 # Enable high concurrency mode if the concurrency type contains 1000 or more
-if [[ $concurrency_type =~ ^([0-9]{4}-[0-9]{3}|[0-9]{3}-[0-9]{4}|[0-9]{4}-[0-9]{4})$ ]]; then
+if [[ $concurrency =~ ^([0-9]{4}-[0-9]{3}|[0-9]{3}-[0-9]{4}|[0-9]{4}-[0-9]{4})$ ]]; then
     enable_high_concurrency=true
 fi
 

--- a/four-node-cluster/4-node-cluster.yml
+++ b/four-node-cluster/4-node-cluster.yml
@@ -27,6 +27,7 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
+          - EnableHighConcurrencyMode
       - Label:
           default: Network Configuration
         Parameters:
@@ -37,8 +38,6 @@ Metadata:
           - DBUsername
           - DBPassword
           - DBInstanceType
-          - DBAllocationStorage
-          - DBIops
           - DBType
           - DBSnapshotId
       - Label:
@@ -47,8 +46,6 @@ Metadata:
           - SessionDBUsername
           - SessionDBPassword
           - SessionDBInstanceType
-          - SessionDBAllocationStorage
-          - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
@@ -274,7 +271,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref DBInstanceType
-      AllocatedStorage: !Ref DBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
       DBSnapshotIdentifier: !Ref DBSnapshotId
@@ -285,7 +282,7 @@ Resources:
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
-      Iops: !Ref DBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -296,7 +293,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISSessionDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref SessionDBInstanceType
-      AllocatedStorage: !Ref SessionDBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
@@ -306,7 +303,7 @@ Resources:
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
-      Iops: !Ref SessionDBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -703,6 +700,12 @@ Parameters:
     Type: String
     MinLength: 8
     NoEcho: true
+  EnableHighConcurrencyMode:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
   DBInstanceType:
     Type: String
     Default: db.m6i.2xlarge
@@ -731,14 +734,6 @@ Parameters:
     Description: Snapshot ID to restore the database from
     Type: String
     Default: ''
-  DBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  DBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   SessionDBUsername:
     Type: String
     MinLength: 4
@@ -768,14 +763,6 @@ Parameters:
       - db.m6i.xlarge
       - db.m6i.2xlarge
       - db.m6i.4xlarge
-  SessionDBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  SessionDBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
@@ -831,3 +818,14 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
+  HighConcurrencyModeMap:
+    "true":
+      DBIops: 5000
+      SessionDBIops: 5000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100
+    "false":
+      DBIops: 1000
+      SessionDBIops: 1000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100

--- a/single-node/single-node.yaml
+++ b/single-node/single-node.yaml
@@ -24,6 +24,7 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
+          - EnableHighConcurrencyMode
       - Label:
           default: Network Configuration
         Parameters:
@@ -34,8 +35,6 @@ Metadata:
           - DBUsername
           - DBPassword
           - DBInstanceType
-          - DBAllocationStorage
-          - DBIops
           - DBType
           - DBSnapshotId
       - Label:
@@ -44,8 +43,6 @@ Metadata:
           - SessionDBUsername
           - SessionDBPassword
           - SessionDBInstanceType
-          - SessionDBAllocationStorage
-          - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
@@ -219,7 +216,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref DBInstanceType
-      AllocatedStorage: !Ref DBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
       DBSnapshotIdentifier: !Ref DBSnapshotId
@@ -230,7 +227,7 @@ Resources:
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
-      Iops: !Ref DBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -241,7 +238,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISSessionDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref SessionDBInstanceType
-      AllocatedStorage: !Ref SessionDBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
@@ -251,7 +248,7 @@ Resources:
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
-      Iops: !Ref SessionDBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -515,6 +512,12 @@ Parameters:
     Type: String
     MinLength: 8
     NoEcho: true
+  EnableHighConcurrencyMode:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
   DBInstanceType:
     Type: String
     Default: db.m6i.2xlarge
@@ -543,14 +546,6 @@ Parameters:
     Description: Snapshot ID to restore the database from
     Type: String
     Default: ''
-  DBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  DBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   SessionDBUsername:
     Type: String
     MinLength: 4
@@ -580,14 +575,6 @@ Parameters:
       - db.m6i.xlarge
       - db.m6i.2xlarge
       - db.m6i.4xlarge
-  SessionDBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  SessionDBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
@@ -643,3 +630,14 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
+  HighConcurrencyModeMap:
+    "true":
+      DBIops: 5000
+      SessionDBIops: 5000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100
+    "false":
+      DBIops: 1000
+      SessionDBIops: 1000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100

--- a/three-node-cluster/3-node-cluster.yml
+++ b/three-node-cluster/3-node-cluster.yml
@@ -27,6 +27,7 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
+          - EnableHighConcurrencyMode
       - Label:
           default: Network Configuration
         Parameters:
@@ -37,8 +38,6 @@ Metadata:
           - DBUsername
           - DBPassword
           - DBInstanceType
-          - DBAllocationStorage
-          - DBIops
           - DBType
           - DBSnapshotId
       - Label:
@@ -47,8 +46,6 @@ Metadata:
           - SessionDBUsername
           - SessionDBPassword
           - SessionDBInstanceType
-          - SessionDBAllocationStorage
-          - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
@@ -248,7 +245,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref DBInstanceType
-      AllocatedStorage: !Ref DBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
       DBSnapshotIdentifier: !Ref DBSnapshotId
@@ -259,7 +256,7 @@ Resources:
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
-      Iops: !Ref DBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -270,7 +267,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISSessionDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref SessionDBInstanceType
-      AllocatedStorage: !Ref SessionDBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
@@ -280,7 +277,7 @@ Resources:
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
-      Iops: !Ref SessionDBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -645,6 +642,12 @@ Parameters:
     Type: String
     MinLength: 8
     NoEcho: true
+  EnableHighConcurrencyMode:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
   DBInstanceType:
     Type: String
     Default: db.m6i.2xlarge
@@ -673,14 +676,6 @@ Parameters:
     Description: Snapshot ID to restore the database from
     Type: String
     Default: ''
-  DBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  DBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   SessionDBUsername:
     Type: String
     MinLength: 4
@@ -710,14 +705,6 @@ Parameters:
       - db.m6i.xlarge
       - db.m6i.2xlarge
       - db.m6i.4xlarge
-  SessionDBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  SessionDBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
@@ -773,3 +760,14 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
+  HighConcurrencyModeMap:
+    "true":
+      DBIops: 5000
+      SessionDBIops: 5000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100
+    "false":
+      DBIops: 1000
+      SessionDBIops: 1000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100

--- a/two-node-cluster/2-node-cluster.yml
+++ b/two-node-cluster/2-node-cluster.yml
@@ -26,6 +26,7 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - BastionInstanceType
+          - EnableHighConcurrencyMode
       - Label:
           default: Network Configuration
         Parameters:
@@ -36,8 +37,6 @@ Metadata:
           - DBUsername
           - DBPassword
           - DBInstanceType
-          - DBAllocationStorage
-          - DBIops
           - DBType
           - DBSnapshotId
       - Label:
@@ -46,8 +45,6 @@ Metadata:
           - SessionDBUsername
           - SessionDBPassword
           - SessionDBInstanceType
-          - SessionDBAllocationStorage
-          - SessionDBIops
       - Label:
           default: Other Configuration
         Parameters:
@@ -221,7 +218,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref DBInstanceType
-      AllocatedStorage: !Ref DBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISDBInstancesuffix
       DBSnapshotIdentifier: !Ref DBSnapshotId
@@ -232,7 +229,7 @@ Resources:
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
-      Iops: !Ref DBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -243,7 +240,7 @@ Resources:
       VPCSecurityGroups:
         - !Ref WSO2ISSessionDBInstanceSecurityGroupsuffix
       DBInstanceClass: !Ref SessionDBInstanceType
-      AllocatedStorage: !Ref SessionDBAllocationStorage
+      AllocatedStorage: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBAllocationStorage]
       BackupRetentionPeriod: '0'
       DBInstanceIdentifier: WSO2ISSessionDBInstancesuffix
       EngineVersion: !FindInMap [DBTypeMap, !Ref DBType, Version]
@@ -253,7 +250,7 @@ Resources:
       MasterUsername: !Ref SessionDBUsername
       MasterUserPassword: !Ref SessionDBPassword
       MultiAZ: 'false'
-      Iops: !Ref SessionDBIops
+      Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, SessionDBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]
       DBSubnetGroupName: !Ref WSO2ISDBSubnetGroupsuffix
@@ -586,6 +583,12 @@ Parameters:
     Type: String
     MinLength: 8
     NoEcho: true
+  EnableHighConcurrencyMode:
+    Type: String
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
   DBInstanceType:
     Type: String
     Default: db.m6i.2xlarge
@@ -614,14 +617,6 @@ Parameters:
     Description: Snapshot ID to restore the database from
     Type: String
     Default: ''
-  DBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  DBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   SessionDBUsername:
     Type: String
     MinLength: 4
@@ -651,14 +646,6 @@ Parameters:
       - db.m6i.xlarge
       - db.m6i.2xlarge
       - db.m6i.4xlarge
-  SessionDBAllocationStorage:
-    Description: Provide storage size in Gigabytes
-    Type: Number
-    Default: 100
-  SessionDBIops:
-    Description: Provide IOps size in numbers
-    Type: Number
-    Default: 1000
   UserTag:
     Description: User tag to be used for tagging AWS resources
     Type: String
@@ -714,3 +701,14 @@ Mappings:
       FromPort: '5432'
       ToPort: '5432'
       DBType: 'postgres'
+  HighConcurrencyModeMap:
+    "true":
+      DBIops: 5000
+      SessionDBIops: 5000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100
+    "false":
+      DBIops: 1000
+      SessionDBIops: 1000
+      DBAllocationStorage: 100
+      SessionDBAllocationStorage: 100


### PR DESCRIPTION
### Related issue
https://github.com/wso2/product-is/issues/21513

### Summary
This pull request introduces a new feature to enable high concurrency mode and updates the related configuration files accordingly. The most important changes include adding a new parameter for concurrency type, modifying the performance script to handle this new parameter, and updating the CloudFormation templates to support high concurrency mode.

### Enhancements to Performance Script:
* Added `concurrency_type` and `enable_high_concurrency` variables in `common/start-performance.sh` to support high concurrency mode. [[1]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR29) [[2]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR43)
* Updated the `getopts` string and case statement to include the new `-r` option for concurrency type. [[1]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL102-R104) [[2]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR127-R129)
* Modified the `run_performance_tests_options` to include `concurrency_type` and added logic to enable high concurrency mode based on the concurrency type. [[1]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cL192-R197) [[2]](diffhunk://#diff-62b3c0a71a56c74a0854a4fe0bfa1f0798389a9005cef227fa3262945f70271cR247-R251)
* Updated the `create_stack_command` to pass the `EnableHighConcurrencyMode` parameter to the CloudFormation stack.

### Updates to CloudFormation Templates:
* Added `EnableHighConcurrencyMode` parameter and removed `DBAllocationStorage` and `DBIops` parameters in `four-node-cluster/4-node-cluster.yml`. [[1]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958R30) [[2]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L40-L41) [[3]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L50-L51) [[4]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958R703-R708) [[5]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L734-L741) [[6]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L771-L778)
* Updated the mappings and resources in `four-node-cluster/4-node-cluster.yml` to use the new high concurrency mode settings. [[1]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L277-R274) [[2]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L288-R285) [[3]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L299-R296) [[4]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958L309-R306) [[5]](diffhunk://#diff-89848d365f523d2c1dadfa3377acb240b1578cf856ec737696c553eb28ee5958R821-R831)

### Similar Updates to Other Templates:
* Applied the same changes to `single-node/single-node.yaml` and `three-node-cluster/3-node-cluster.yml` to support high concurrency mode. [[1]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80R27) [[2]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L37-L38) [[3]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L47-L48) [[4]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L222-R219) [[5]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L233-R230) [[6]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L244-R241) [[7]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L254-R251) [[8]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80R515-R520) [[9]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L546-L553) [[10]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80L583-L590) [[11]](diffhunk://#diff-5e8c2e11dcceddf85224ae6ba7952e1894e6f4ece11803775e3756f3fd021c80R633-R643) [[12]](diffhunk://#diff-e4d7ddc3c354002f96893fcf19de5b8a5b1e7ea172af6dbcc2400f7c4ac65bdfR30) [[13]](diffhunk://#diff-e4d7ddc3c354002f96893fcf19de5b8a5b1e7ea172af6dbcc2400f7c4ac65bdfL40-L41) [[14]](diffhunk://#diff-e4d7ddc3c354002f96893fcf19de5b8a5b1e7ea172af6dbcc2400f7c4ac65bdfL50-L51) [[15]](diffhunk://#diff-e4d7ddc3c354002f96893fcf19de5b8a5b1e7ea172af6dbcc2400f7c4ac65bdfL251-R248) [[16]](diffhunk://#diff-e4d7ddc3c354002f96893fcf19de5b8a5b1e7ea172af6dbcc2400f7c4ac65bdfL262-R259) [[17]](diffhunk://#diff-e4d7ddc3c354002f96893fcf19de5b8a5b1e7ea172af6dbcc2400f7c4ac65bdfL273-R270)

These changes collectively enable the high concurrency mode feature, providing better performance for high-load scenarios.