### PR TITLE
Fix user created with country issue

### DIFF
--- a/common/jmeter/setup/TestData_SCIM2_Add_Sub_Org_Users.jmx
+++ b/common/jmeter/setup/TestData_SCIM2_Add_Sub_Org_Users.jmx
@@ -486,7 +486,7 @@ vars.put(&quot;subOrgFiler&quot;, new String(subOrgFiler));
                 <elementProp name="" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
                   <stringProp name="Argument.value">{&#xd;
-   &quot;schemas&quot;:[&quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;, &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;, &quot;urn:scim:wso2:schema&quot;],&#xd;
+   &quot;schemas&quot;:[&quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;, &quot;urn:scim:wso2:schema&quot;, &quot;urn:scim:wso2:schema&quot;],&#xd;
    &quot;userName&quot;:&quot;${usernamePrefix}${user_index}&quot;,&#xd;
    &quot;password&quot;:&quot;${userPassword}&quot;,&#xd;
    &quot;name&quot;:{&#xd;
@@ -497,7 +497,7 @@ vars.put(&quot;subOrgFiler&quot;, new String(subOrgFiler));
       &quot;accountLocked&quot;:&quot;false&quot;&#xd;
    },&#xd;
    &quot;emails&quot;:[&quot;${useremailPrefix}${user_index}@test.com&quot;],&#xd;
-   &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;: &#xd;
+   &quot;urn:scim:wso2:schema&quot;: &#xd;
    {&#xd;
    		&quot;country&quot;:&quot;Sri Lanka&quot;&#xd;
    },&#xd;

--- a/common/jmeter/setup/TestData_SCIM2_Add_User.jmx
+++ b/common/jmeter/setup/TestData_SCIM2_Add_User.jmx
@@ -350,7 +350,7 @@
             &quot;data&quot;: {&#xd;
                 &quot;schemas&quot;: [&#xd;
                     &quot;urn:ietf:params:scim:schemas:core:2.0:User&quot;,&#xd;
-                    &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;,&#xd;
+                    &quot;urn:scim:wso2:schema&quot;,&#xd;
                     &quot;urn:scim:wso2:schema&quot;&#xd;
                 ],&#xd;
                 &quot;userName&quot;: &quot;${usernamePrefix}${user_index}&quot;,&#xd;
@@ -365,7 +365,7 @@
                 &quot;emails&quot;: [&#xd;
                     &quot;${useremailPrefix}${user_index}@test.com&quot;&#xd;
                 ],&#xd;
-                &quot;urn:ietf:params:scim:schemas:extension:enterprise:2.0:User&quot;: {&#xd;
+                &quot;urn:scim:wso2:schema&quot;: {&#xd;
                     &quot;country&quot;: &quot;Sri Lanka&quot;&#xd;
                 },&#xd;
                 &quot;roles&quot;: [&#xd;


### PR DESCRIPTION
This pull request includes several changes to the `TestData_SCIM2_Add_Sub_Org_Users.jmx` and `TestData_SCIM2_Add_User.jmx` files to update the SCIM schema references. The most important changes include replacing the `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema with `urn:scim:wso2:schema` in various parts of the files.

Updates to SCIM schema references:

* [`common/jmeter/setup/TestData_SCIM2_Add_Sub_Org_Users.jmx`](diffhunk://#diff-5bb2b435a51ae9addf6d7697e03ff79f293bca6c0dcfcd51954082e210f667f6L489-R489): Updated the `schemas` array to replace `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` with `urn:scim:wso2:schema`.
* [`common/jmeter/setup/TestData_SCIM2_Add_Sub_Org_Users.jmx`](diffhunk://#diff-5bb2b435a51ae9addf6d7697e03ff79f293bca6c0dcfcd51954082e210f667f6L500-R500): Updated the schema reference for the `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` attribute to `urn:scim:wso2:schema`.
* [`common/jmeter/setup/TestData_SCIM2_Add_User.jmx`](diffhunk://#diff-a909bd63bb6a252730da4420ec8712e0ed5ff0588b636040c768326b2e13b9aeL353-R353): Updated the `schemas` array to replace `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` with `urn:scim:wso2:schema`.
* [`common/jmeter/setup/TestData_SCIM2_Add_User.jmx`](diffhunk://#diff-a909bd63bb6a252730da4420ec8712e0ed5ff0588b636040c768326b2e13b9aeL368-R368): Updated the schema reference for the `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` attribute to `urn:scim:wso2:schema`.