### PR TITLE
Add useDelay parameter to JMeter test plans

### DIFF
--- a/common/jmeter/oidc/B2B_OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/B2B_OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -563,7 +568,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           </HTTPSamplerProxy>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-              <stringProp name="ConstantTimer.delay">6000</stringProp>
+              <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
               <stringProp name="RandomTimer.range">2000</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
@@ -842,7 +847,7 @@ if (federatedIDPRedirectURL_g.equals(&quot;2&quot;)) {
             </HTTPSamplerProxy>
             <hashTree>
               <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-                <stringProp name="ConstantTimer.delay">2000</stringProp>
+                <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
                 <stringProp name="RandomTimer.range">1000</stringProp>
               </GaussianRandomTimer>
               <hashTree/>
@@ -1424,7 +1429,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             </HTTPSamplerProxy>
             <hashTree>
               <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-                <stringProp name="ConstantTimer.delay">6000</stringProp>
+                <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
                 <stringProp name="RandomTimer.range">2000</stringProp>
               </GaussianRandomTimer>
               <hashTree/>
@@ -1703,7 +1708,7 @@ if (federatedIDPRedirectURL_g.equals(&quot;2&quot;)) {
               </HTTPSamplerProxy>
               <hashTree>
                 <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-                  <stringProp name="ConstantTimer.delay">2000</stringProp>
+                  <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
                   <stringProp name="RandomTimer.range">1000</stringProp>
                 </GaussianRandomTimer>
                 <hashTree/>

--- a/common/jmeter/oidc/B2B_OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/B2B_OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/B2B_OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/B2B_OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -569,7 +569,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
               <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-              <stringProp name="RandomTimer.range">2000</stringProp>
+              <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -848,7 +848,7 @@ if (federatedIDPRedirectURL_g.equals(&quot;2&quot;)) {
             <hashTree>
               <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
                 <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
-                <stringProp name="RandomTimer.range">1000</stringProp>
+                <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 1000 : 0,)}</stringProp>
               </GaussianRandomTimer>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -1430,7 +1430,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <hashTree>
               <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
                 <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-                <stringProp name="RandomTimer.range">2000</stringProp>
+                <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
               </GaussianRandomTimer>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -1709,7 +1709,7 @@ if (federatedIDPRedirectURL_g.equals(&quot;2&quot;)) {
               <hashTree>
                 <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
                   <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
-                  <stringProp name="RandomTimer.range">1000</stringProp>
+                  <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 1000 : 0,)}</stringProp>
                 </GaussianRandomTimer>
                 <hashTree/>
                 <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC- Authorization Code Redirect With Consent" enabled="true">
       <stringProp name="TestPlan.comments">Login to </stringProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -543,7 +543,7 @@ ${password}</stringProp>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
               <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
-              <stringProp name="RandomTimer.range">1000</stringProp>
+              <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 1000 : 0,)}</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent.jmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.3">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.5">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="OIDC- Authorization Code Redirect With Consent" enabled="true">
       <stringProp name="TestPlan.comments">Login to </stringProp>
@@ -122,6 +122,11 @@
           <elementProp name="deployment" elementType="Argument">
             <stringProp name="Argument.name">deployment</stringProp>
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
@@ -537,7 +542,7 @@ ${password}</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-              <stringProp name="ConstantTimer.delay">2000</stringProp>
+              <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
               <stringProp name="RandomTimer.range">1000</stringProp>
             </GaussianRandomTimer>
             <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -585,7 +585,7 @@ ${password}</stringProp>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
               <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
-              <stringProp name="RandomTimer.range">1000</stringProp>
+              <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 1000 : 0,)}</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
@@ -579,7 +584,7 @@ ${password}</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-              <stringProp name="ConstantTimer.delay">2000</stringProp>
+              <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
               <stringProp name="RandomTimer.range">1000</stringProp>
             </GaussianRandomTimer>
             <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_And_Groups.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_And_Groups.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -585,7 +585,7 @@ ${password}</stringProp>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
               <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
-              <stringProp name="RandomTimer.range">1000</stringProp>
+              <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 1000 : 0,)}</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_And_Groups.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_And_Groups.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_And_Groups.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_And_Groups.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
@@ -579,7 +584,7 @@ ${password}</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-              <stringProp name="ConstantTimer.delay">2000</stringProp>
+              <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
               <stringProp name="RandomTimer.range">1000</stringProp>
             </GaussianRandomTimer>
             <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
@@ -592,7 +592,7 @@ ${password}</stringProp>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
               <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
-              <stringProp name="RandomTimer.range">1000</stringProp>
+              <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 1000 : 0,)}</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
@@ -586,7 +591,7 @@ ${password}</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-              <stringProp name="ConstantTimer.delay">2000</stringProp>
+              <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
               <stringProp name="RandomTimer.range">1000</stringProp>
             </GaussianRandomTimer>
             <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_And_Groups.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_And_Groups.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_And_Groups.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_And_Groups.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_And_Groups.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_And_Groups.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
@@ -124,6 +124,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -386,7 +391,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
@@ -126,7 +126,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
+++ b/common/jmeter/oidc/OIDC_AuthCode_Redirect_WithoutConsent_Retrieve_User_Attributes_Groups_And_Roles.jmx
@@ -392,7 +392,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">

--- a/common/jmeter/perf-test-is.sh
+++ b/common/jmeter/perf-test-is.sh
@@ -92,7 +92,7 @@ use_db_snapshot="false"
 deployment=""
 
 # Use delays inside tests to mimic user input
-use_delay=false
+use_delay=true
 
 # JWT Bearer Grant Flow
 jwt_token_client_secret=""

--- a/common/jmeter/perf-test-is.sh
+++ b/common/jmeter/perf-test-is.sh
@@ -91,6 +91,9 @@ mode=""
 use_db_snapshot="false"
 deployment=""
 
+# Use delays inside tests to mimic user input
+use_delay=false
+
 # JWT Bearer Grant Flow
 jwt_token_client_secret=""
 jwt_token_user_password=""
@@ -155,11 +158,12 @@ function usage() {
     echo "-p: Identity Server Port. Default $default_is_port."
     echo "-b: Database type."
     echo "-a: Use existing snapshot for the database."
+    echo "-z: Use delays inside tests to mimic user input."
     echo "-h: Display this help and exit."
     echo ""
 }
 
-while getopts "c:m:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:v:x:o:y:b:a:h" opts; do
+while getopts "c:m:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:v:x:o:y:b:a:z:h" opts; do
     case $opts in
     c)
         concurrent_users+=("${OPTARG}")
@@ -192,19 +196,22 @@ while getopts "c:m:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:v:x:o:y:b:a:h" opts; do
         deployment=${OPTARG}
         ;;
     n)
-        noOfTenants=("${OPTARG}")
+        noOfTenants=${OPTARG}
         ;;
     s)
-        spCount=("${OPTARG}")
+        spCount=${OPTARG}
         ;;
     q)
-        idpCount=("${OPTARG}")
+        idpCount=${OPTARG}
         ;;
     u)
-        userCount=("${OPTARG}")
+        userCount=${OPTARG}
         ;;
     t)
         estimate=true
+        ;;
+    z)
+        use_delay=${OPTARG}
         ;;
     p)
         is_port=${OPTARG}
@@ -656,7 +663,7 @@ function test_scenarios() {
                 mkdir -p "$report_location"
 
                 time=$(expr "$test_duration" \* 60)
-                declare -a jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "port=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "userCount=$userCount")
+                declare -a jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "port=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "userCount=$userCount" "useDelay=$use_delay")
 
                 local tenantMode=${scenario[tenantMode]}
                 if [ "$tenantMode" = true ]; then

--- a/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
+++ b/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
@@ -397,7 +397,7 @@ ${password}
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
             <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-            <stringProp name="RandomTimer.range">2000</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP 200" enabled="true">
@@ -696,7 +696,7 @@ ${password}
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
               <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
-              <stringProp name="RandomTimer.range">2000</stringProp>
+              <stringProp name="RandomTimer.range">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
             </GaussianRandomTimer>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP 200" enabled="true">

--- a/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
+++ b/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
@@ -127,7 +127,7 @@
           </elementProp>
           <elementProp name="useDelay" elementType="Argument">
             <stringProp name="Argument.name">useDelay</stringProp>
-            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,false)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>

--- a/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
+++ b/common/jmeter/saml/SAML2_SSO_Redirect_Binding.jmx
@@ -125,6 +125,11 @@
             <stringProp name="Argument.value">${__P(deployment,&quot;active-passive&quot;)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -391,7 +396,7 @@ ${password}
         </HTTPSamplerProxy>
         <hashTree>
           <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-            <stringProp name="ConstantTimer.delay">6000</stringProp>
+            <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
             <stringProp name="RandomTimer.range">2000</stringProp>
           </GaussianRandomTimer>
           <hashTree/>
@@ -690,7 +695,7 @@ ${password}
           </HTTPSamplerProxy>
           <hashTree>
             <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
-              <stringProp name="ConstantTimer.delay">6000</stringProp>
+              <stringProp name="ConstantTimer.delay">${__groovy(${useDelay}.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
               <stringProp name="RandomTimer.range">2000</stringProp>
             </GaussianRandomTimer>
             <hashTree/>

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -42,7 +42,7 @@ db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
 enable_high_concurrency=false
 use_db_snapshot=false
-use_delay=false
+use_delay=true
 db_snapshot_id=""
 
 results_dir="$PWD/results-$timestamp"

--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -42,6 +42,7 @@ db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
 enable_high_concurrency=false
 use_db_snapshot=false
+use_delay=false
 db_snapshot_id=""
 
 results_dir="$PWD/results-$timestamp"
@@ -54,8 +55,8 @@ function usage() {
     echo "$0 -k <key_file> -c <certificate_name> -j <jmeter_setup_path> -n <IS_zip_file_path>"
     echo "   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>] [-r <concurrency>]"
     echo "   [-i <wso2_is_instance_type>] [-b <bastion_instance_type>] [-t <keystore_type>] [-m <db_type>]"
-    echo "   [-l <is_case_insensitive_username_and_attributes>]"
-    echo "   [-w <minimum_stack_creation_wait_time>] [-h]"
+    echo "   [-l <is_case_insensitive_username_and_attributes>] [-z <use_delay>] [-q <user_tag>]"
+    echo "   [-w <minimum_stack_creation_wait_time>] [-g <number_of_nodes>] [-v <testing_mode>] [-h]"
     echo ""
     echo "-k: The Amazon EC2 key file to be used to access the instances."
     echo "-c: The name of the IAM certificate."
@@ -74,11 +75,12 @@ function usage() {
     echo "-w: The minimum time to wait in minutes before polling for cloudformation stack's CREATE_COMPLETE status."
     echo "    Default: $default_minimum_stack_creation_wait_time minutes."
     echo "-v: The required testing mode [FULL/QUICK]"
-    echo "-h: Display this help and exit."
+    echo "-t: Keystore type. Default: $keystore_type."
     echo "-g: Number of IS nodes."
-    echo "-t: Keystore type. Default: PKCS12."
-    echo "-m: Database type. Default: mysql."
-    echo "-l: Case insensitivity of the username and attributes. Default: false."
+    echo "-m: Database type. Default: $db_type."
+    echo "-l: Case insensitivity of the username and attributes. Default: $is_case_insensitive_username_and_attributes."
+    echo "-z: Use delays inside tests to mimic user input. Default: $use_delay."
+    echo "-h: Display this help and exit."
     echo ""
 }
 
@@ -101,7 +103,7 @@ function execute_db_command() {
     ssh_bastion_cmd "$db_command"
 }
 
-while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:r:h" opts; do
+while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:z:r:h" opts; do
     case $opts in
     q)
         user_tag=${OPTARG}
@@ -153,6 +155,9 @@ while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:r:h" opts; do
         ;;
     l)
         is_case_insensitive_username_and_attributes=${OPTARG}
+        ;;
+    z)
+        use_delay=${OPTARG}
         ;;
     h)
         usage


### PR DESCRIPTION
### Purpose

useDelay parameter is added to be able to run scheduled tests without a delay