### PR TITLE
Remove use_delay option from start-performance.sh

### DIFF
--- a/common/start-performance.sh
+++ b/common/start-performance.sh
@@ -42,7 +42,6 @@ db_type="mysql"
 is_case_insensitive_username_and_attributes="false"
 enable_high_concurrency=false
 use_db_snapshot=false
-use_delay=true
 db_snapshot_id=""
 
 results_dir="$PWD/results-$timestamp"
@@ -55,7 +54,7 @@ function usage() {
     echo "$0 -k <key_file> -c <certificate_name> -j <jmeter_setup_path> -n <IS_zip_file_path>"
     echo "   [-u <db_username>] [-p <db_password>] [-e <db_instance_type>] [-s <db_snapshot_id>] [-r <concurrency>]"
     echo "   [-i <wso2_is_instance_type>] [-b <bastion_instance_type>] [-t <keystore_type>] [-m <db_type>]"
-    echo "   [-l <is_case_insensitive_username_and_attributes>] [-z <use_delay>] [-q <user_tag>]"
+    echo "   [-l <is_case_insensitive_username_and_attributes>] [-q <user_tag>]"
     echo "   [-w <minimum_stack_creation_wait_time>] [-g <number_of_nodes>] [-v <testing_mode>] [-h]"
     echo ""
     echo "-k: The Amazon EC2 key file to be used to access the instances."
@@ -79,7 +78,6 @@ function usage() {
     echo "-g: Number of IS nodes."
     echo "-m: Database type. Default: $db_type."
     echo "-l: Case insensitivity of the username and attributes. Default: $is_case_insensitive_username_and_attributes."
-    echo "-z: Use delays inside tests to mimic user input. Default: $use_delay."
     echo "-h: Display this help and exit."
     echo ""
 }
@@ -103,7 +101,7 @@ function execute_db_command() {
     ssh_bastion_cmd "$db_command"
 }
 
-while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:z:r:h" opts; do
+while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:r:h" opts; do
     case $opts in
     q)
         user_tag=${OPTARG}
@@ -155,9 +153,6 @@ while getopts "q:k:c:j:n:u:p:s:e:i:b:w:t:g:m:l:z:r:h" opts; do
         ;;
     l)
         is_case_insensitive_username_and_attributes=${OPTARG}
-        ;;
-    z)
-        use_delay=${OPTARG}
         ;;
     h)
         usage


### PR DESCRIPTION
This pull request includes changes to the `common/start-performance.sh` script to remove the `use_delay` option and its associated functionality. The most important changes include updates to the usage function, the `getopts` string, and the case statement handling the options.
