### PR TITLE
Add server restart after initial start-up

### DIFF
--- a/common/deployment/setup/update-is-conf.sh
+++ b/common/deployment/setup/update-is-conf.sh
@@ -257,3 +257,7 @@ echo "Starting WSO2 IS server..."
 echo "-------------------------------------------"
 ./wso2is/bin/wso2server.sh start
 sleep 100s
+./wso2is/bin/wso2server.sh stop
+sleep 100s
+./wso2is/bin/wso2server.sh start
+sleep 100s

--- a/common/deployment/setup/update-is-conf.sh
+++ b/common/deployment/setup/update-is-conf.sh
@@ -257,6 +257,10 @@ echo "Starting WSO2 IS server..."
 echo "-------------------------------------------"
 ./wso2is/bin/wso2server.sh start
 sleep 100s
+
+echo ""
+echo "Restarting WSO2 IS server..."
+echo "-------------------------------------------"
 ./wso2is/bin/wso2server.sh stop
 sleep 10s
 ./wso2is/bin/wso2server.sh start

--- a/common/deployment/setup/update-is-conf.sh
+++ b/common/deployment/setup/update-is-conf.sh
@@ -258,6 +258,6 @@ echo "-------------------------------------------"
 ./wso2is/bin/wso2server.sh start
 sleep 100s
 ./wso2is/bin/wso2server.sh stop
-sleep 100s
+sleep 10s
 ./wso2is/bin/wso2server.sh start
-sleep 100s
+sleep 60s


### PR DESCRIPTION
## Purpose

Addresses https://github.com/wso2/product-is/issues/23411.

During the initial start-up, when the console app fetches the app details from the db for caching, it returns null for the audience, which gets set as "organization" as the default even though the db stores the correct value as "application". It seems this is likely due to a slowness in the data writing as this issue isn't reproducible with postgres, mssql or a local mysql setup.

We use the corrupted value during the sub-org creation which gets detected as a changed audience and tries to update the audience which is the cause of the failure.

With the restarts as a workaround, by the time the server is restarted, the data is already written to the db and the correct values are fetched and cached, which solves the issue.

## Related Issues

- https://github.com/wso2/product-is/issues/23411