### PR TITLE
Add random delay capability for app native cred submit

### DIFF
--- a/common/jmeter/app-native-auth/App_Native_Auth.jmx
+++ b/common/jmeter/app-native-auth/App_Native_Auth.jmx
@@ -403,6 +403,11 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
+          <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">${__groovy(&quot;${useDelay}&quot;.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(&quot;${useDelay}&quot;.equals(&quot;true&quot;) ? 2000 : 0,)}</stringProp>
+          </GaussianRandomTimer>
+          <hashTree/>
           <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
             <collectionProp name="HeaderManager.headers">
               <elementProp name="" elementType="Header">


### PR DESCRIPTION
This PR adds the capability to add a random delay capability for app native auth credential submit. This can be used by setting the useDelay to true. The delay has a constant delay of 6 seconds + a variable delay of 2 seconds (these time are used to be consistent with the delays available in the other tests)