### PR TITLE
Update IS node instance java version to 21

### DIFF
--- a/four-node-cluster/4-node-cluster.yml
+++ b/four-node-cluster/4-node-cluster.yml
@@ -548,7 +548,7 @@ Resources:
             DEBIAN_FRONTEND=noninteractive env ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
             export PATH=/opt/mssql-tools/bin:$PATH
             echo "export PATH=$PATH" >>/etc/environment
-            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-11.0.15.1_linux-x64_bin.tar.gz
+            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-21.0.5.11_linux-x64_bin.tar.gz
             sudo mkdir /usr/lib/jvm
             sudo tar -xvf jdk-setup.tar.gz -C /usr/lib/jvm
             sudo mv /usr/lib/jvm/jdk* /usr/lib/jvm/jdk

--- a/single-node/single-node.yaml
+++ b/single-node/single-node.yaml
@@ -479,7 +479,7 @@ Resources:
             DEBIAN_FRONTEND=noninteractive env ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
             export PATH=/opt/mssql-tools/bin:$PATH
             echo "export PATH=$PATH" >>/etc/environment
-            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-11.0.15.1_linux-x64_bin.tar.gz
+            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-21.0.5.11_linux-x64_bin.tar.gz
             sudo mkdir /usr/lib/jvm
             sudo tar -xvf jdk-setup.tar.gz -C /usr/lib/jvm
             sudo mv /usr/lib/jvm/jdk* /usr/lib/jvm/jdk

--- a/three-node-cluster/3-node-cluster.yml
+++ b/three-node-cluster/3-node-cluster.yml
@@ -514,7 +514,7 @@ Resources:
             DEBIAN_FRONTEND=noninteractive env ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
             export PATH=/opt/mssql-tools/bin:$PATH
             echo "export PATH=$PATH" >>/etc/environment
-            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-11.0.15.1_linux-x64_bin.tar.gz
+            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-21.0.5.11_linux-x64_bin.tar.gz
             sudo mkdir /usr/lib/jvm
             sudo tar -xvf jdk-setup.tar.gz -C /usr/lib/jvm
             sudo mv /usr/lib/jvm/jdk* /usr/lib/jvm/jdk

--- a/two-node-cluster/2-node-cluster.yml
+++ b/two-node-cluster/2-node-cluster.yml
@@ -479,7 +479,7 @@ Resources:
             DEBIAN_FRONTEND=noninteractive env ACCEPT_EULA=Y apt-get install -y mssql-tools unixodbc-dev
             export PATH=/opt/mssql-tools/bin:$PATH
             echo "export PATH=$PATH" >>/etc/environment
-            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-11.0.15.1_linux-x64_bin.tar.gz
+            curl -o jdk-setup.tar.gz https://performance-is-packs.s3.amazonaws.com/resources/jdk-21.0.5.11_linux-x64_bin.tar.gz
             sudo mkdir /usr/lib/jvm
             sudo tar -xvf jdk-setup.tar.gz -C /usr/lib/jvm
             sudo mv /usr/lib/jvm/jdk* /usr/lib/jvm/jdk


### PR DESCRIPTION
## Purpose
> Note $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Java Development Kit (JDK) version from 11 to 21 across all cluster deployment configurations (single-node, 2-node, 3-node, and 4-node clusters).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->