### PR TITLE
Add failsafe for nginx failures.

### DIFF
--- a/common/deployment/setup/setup-nginx.sh
+++ b/common/deployment/setup/setup-nginx.sh
@@ -62,6 +62,22 @@ while getopts "n:i:w:j:k:h" opts; do
 done
 
 echo ""
+echo "Waiting for nginx to be installed..."
+echo "============================================"
+nginx_wait_attempts=0
+nginx_max_attempts=20
+until systemctl list-units --type=service 2>/dev/null | grep -q "nginx.service"; do
+    nginx_wait_attempts=$((nginx_wait_attempts + 1))
+    if [[ $nginx_wait_attempts -ge $nginx_max_attempts ]]; then
+        echo "ERROR: nginx did not become available after $((nginx_max_attempts * 15)) seconds. Exiting."
+        exit 1
+    fi
+    echo "nginx not yet available, waiting 15s... (attempt $nginx_wait_attempts/$nginx_max_attempts)"
+    sleep 15
+done
+echo "nginx is ready"
+
+echo ""
 echo "Coping files..."
 echo "============================================"
 sudo cp resources/server.* /etc/nginx/ssl/is/

--- a/four-node-cluster/4-node-cluster.yml
+++ b/four-node-cluster/4-node-cluster.yml
@@ -511,6 +511,9 @@ Resources:
 
           - - '#!/bin/bash'
             - 'export PATH=~/.local/bin:$PATH'
+            - 'curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null'
+            - 'echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" | sudo tee /etc/apt/sources.list.d/nginx.list'
+            - 'echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | sudo tee /etc/apt/preferences.d/99nginx'
             - apt-get update
             - DEBIAN_FRONTEND=noninteractive apt-get install -yq nginx
             - mkdir -p /etc/nginx/ssl/is

--- a/single-node/single-node.yaml
+++ b/single-node/single-node.yaml
@@ -442,6 +442,9 @@ Resources:
 
           - - '#!/bin/bash'
             - 'export PATH=~/.local/bin:$PATH'
+            - 'curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null'
+            - 'echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" | sudo tee /etc/apt/sources.list.d/nginx.list'
+            - 'echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | sudo tee /etc/apt/preferences.d/99nginx'
             - apt-get update
             - DEBIAN_FRONTEND=noninteractive apt-get install -yq nginx
             - mkdir -p /etc/nginx/ssl/is

--- a/three-node-cluster/3-node-cluster.yml
+++ b/three-node-cluster/3-node-cluster.yml
@@ -477,6 +477,9 @@ Resources:
 
           - - '#!/bin/bash'
             - 'export PATH=~/.local/bin:$PATH'
+            - 'curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null'
+            - 'echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" | sudo tee /etc/apt/sources.list.d/nginx.list'
+            - 'echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | sudo tee /etc/apt/preferences.d/99nginx'
             - apt-get update
             - DEBIAN_FRONTEND=noninteractive apt-get install -yq nginx
             - mkdir -p /etc/nginx/ssl/is

--- a/two-node-cluster/2-node-cluster.yml
+++ b/two-node-cluster/2-node-cluster.yml
@@ -442,6 +442,9 @@ Resources:
 
           - - '#!/bin/bash'
             - 'export PATH=~/.local/bin:$PATH'
+            - 'curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null'
+            - 'echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu $(lsb_release -cs) nginx" | sudo tee /etc/apt/sources.list.d/nginx.list'
+            - 'echo -e "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" | sudo tee /etc/apt/preferences.d/99nginx'
             - apt-get update
             - DEBIAN_FRONTEND=noninteractive apt-get install -yq nginx
             - mkdir -p /etc/nginx/ssl/is


### PR DESCRIPTION
## Purpose
> $subject

Fixes intermittent failure
```
Coping files to NGinx instance...
============================================
Warning: Permanently added '10.0.1.7' (ECDSA) to the list of known hosts.

Setting up NGinx...
============================================

Coping files...
============================================

Adding IS IPs to conf file...
============================================
cp: cannot create regular file '/etc/nginx/conf.d/': Not a directory
sed: can't read /etc/nginx/conf.d/is.conf: No such file or directory
error 1
```